### PR TITLE
Fix start page appearing to be stuck checking for package updates

### DIFF
--- a/Cork/Views/Start Page/Start Page.swift
+++ b/Cork/Views/Start Page/Start Page.swift
@@ -16,7 +16,8 @@ struct StartPage: View
 
     @State var updateProgressTracker: UpdateProgressTracker
 
-    @State var upgradeablePackages: [BrewPackage] = .init()
+    @State private var isLoadingUpgradeablePackages = true
+    @State private var upgradeablePackages: [BrewPackage] = .init()
 
     @State private var isDisclosureGroupExpanded: Bool = false
     
@@ -26,7 +27,7 @@ struct StartPage: View
     {
         VStack
         {
-            if upgradeablePackages.isEmpty
+            if isLoadingUpgradeablePackages
             {
                 ProgressView
                 {
@@ -160,9 +161,11 @@ struct StartPage: View
         .padding()
         .onAppear
         {
-            Task
+            Task(priority: .high)
             {
+                isLoadingUpgradeablePackages = true
                 upgradeablePackages = await getListOfUpgradeablePackages()
+                isLoadingUpgradeablePackages = false
             }
         }
         .sheet(isPresented: $isShowingMaintenanceSheet) {


### PR DESCRIPTION
I opened Cork and found that it was stuck in the 'checking for package updates' state with a loading indicator. The `StartPage` view would always show the loading state as long as `upgradeablePackages.isEmpty` was `true`, but in my case `upgradeablePackages` was always empty as there were no packages to update.