### PR TITLE
+ Real-time stream from shell interface

### DIFF
--- a/Cork/Models/Terminal Output.swift
+++ b/Cork/Models/Terminal Output.swift
@@ -12,3 +12,9 @@ struct TerminalOutput
     let standardOutput: String
     let standardError: String
 }
+
+enum StreamedTerminalOutput
+{
+    case standardOutput(String)
+    case standardError(String)
+}


### PR DESCRIPTION
This PR:
* Adds a function to produce an async stream of terminal output incrementally as it's received (standard output & standard error)
* Re-works the existing `shell` function to give standard output & standard error all at once via the new stream function – matching the existing function's behaviour

Hoping this fulfils the requirements listed in the README! 😅 

I've lightly tested and found nothing obviously broken by changing the underlying shell interface implementation. Adding print statements showed each line of standard output being logged.

Example usage:
```swift
for await output in shell("/opt/homebrew/bin/brew", ["install", package.name])
{
    // `switch` on `output` or do something else
    print(output)
}
```