### PR TITLE
~ Change terminology from 'tap a tap' to 'add a tap'

### DIFF
--- a/Cork/App State.swift
+++ b/Cork/App State.swift
@@ -13,13 +13,13 @@ class AppState: ObservableObject {
     @Published var isShowingUninstallationSheet: Bool = false
     @Published var isShowingMaintenanceSheet: Bool = false
     @Published var isShowingFastCacheDeletionMaintenanceView: Bool = false
-    @Published var isShowingTapATapSheet: Bool = false
+    @Published var isShowingAddTapSheet: Bool = false
     @Published var isShowingUpdateSheet: Bool = false
     
     @Published var isShowingUninstallationProgressView: Bool = false
     @Published var isShowingUninstallationNotPossibleDueToDependencyAlert: Bool = false
     @Published var offendingDependencyProhibitingUninstallation: String = ""
-    @Published var isShowingUntappingFailedAlert: Bool = false
+    @Published var isShowingRemoveTapFailedAlert: Bool = false
     
     @Published var isLoadingFormulae: Bool = true
     @Published var isLoadingCasks: Bool = true

--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -59,7 +59,7 @@ struct ContentView: View
 
                     Button
                     {
-                        appState.isShowingTapATapSheet.toggle()
+                        appState.isShowingAddTapSheet.toggle()
                     } label: {
                         Label
                         {
@@ -68,7 +68,7 @@ struct ContentView: View
                             Image(systemName: "spigot")
                         }
                     }
-                    .help("Tap a new tap")
+                    .help("Add a new tap")
 
                     Button
                     {
@@ -132,9 +132,9 @@ struct ContentView: View
         {
             AddFormulaView(isShowingSheet: $appState.isShowingInstallationSheet)
         }
-        .sheet(isPresented: $appState.isShowingTapATapSheet)
+        .sheet(isPresented: $appState.isShowingAddTapSheet)
         {
-            AddTapView(isShowingSheet: $appState.isShowingTapATapSheet)
+            AddTapView(isShowingSheet: $appState.isShowingAddTapSheet)
         }
         .sheet(isPresented: $appState.isShowingUpdateSheet)
         {

--- a/Cork/CorkApp.swift
+++ b/Cork/CorkApp.swift
@@ -70,9 +70,9 @@ struct CorkApp: App
 
                 Button
                 {
-                    appState.isShowingTapATapSheet.toggle()
+                    appState.isShowingAddTapSheet.toggle()
                 } label: {
-                    Text("Tap a tap")
+                    Text("Add a Tap")
                 }
                 .keyboardShortcut("n", modifiers: [.command, .option])
 

--- a/Cork/Logic/Load up Tapped Taps.swift
+++ b/Cork/Logic/Load up Tapped Taps.swift
@@ -15,6 +15,6 @@ func loadUpTappedTaps(into tracker: AvailableTaps) async -> Void
     let availableTaps = availableTapsRaw.standardOutput.components(separatedBy: "\n")
     
     for tap in availableTaps {
-        tracker.tappedTaps.append(BrewTap(name: tap))
+        tracker.addedTaps.append(BrewTap(name: tap))
     }
 }

--- a/Cork/Logic/Shell/Brew Interface.swift
+++ b/Cork/Logic/Shell/Brew Interface.swift
@@ -41,9 +41,9 @@ func getListOfUpgradeablePackages() async -> [BrewPackage]
     return finalOutdatedPackages
 }
 
-func tapAtap(tapName: String) async -> String
+func addTap(name: String) async -> String
 {
-    let tapResult = await shell("/opt/homebrew/bin/brew", ["tap", tapName]).standardError
+    let tapResult = await shell("/opt/homebrew/bin/brew", ["tap", name]).standardError
     
     print("Tapping result: \(tapResult)")
     
@@ -55,9 +55,9 @@ enum UntapError: Error
     case couldNotUntap
 }
 
-func untapATap(tapName: String, availableTaps: AvailableTaps, appState: AppState) async throws -> Void
+func removeTap(name: String, availableTaps: AvailableTaps, appState: AppState) async throws -> Void
 {
-    let untapResult = await shell("/opt/homebrew/bin/brew", ["untap", tapName]).standardError
+    let untapResult = await shell("/opt/homebrew/bin/brew", ["untap", name]).standardError
     print("Untapping result: \(untapResult)")
     
     if untapResult.contains("Untapped")
@@ -65,7 +65,7 @@ func untapATap(tapName: String, availableTaps: AvailableTaps, appState: AppState
         print("Untapping was successful")
         DispatchQueue.main.async {
             withAnimation {
-                availableTaps.tappedTaps.removeAll(where: { $0.name == tapName })
+                availableTaps.addedTaps.removeAll(where: { $0.name == name })
             }
         }
     }
@@ -73,7 +73,7 @@ func untapATap(tapName: String, availableTaps: AvailableTaps, appState: AppState
     {
         print("Untapping failed")
         
-        appState.isShowingUntappingFailedAlert = true
+        appState.isShowingRemoveTapFailedAlert = true
         
         throw UntapError.couldNotUntap
     }

--- a/Cork/Models/Brew Data Storage.swift
+++ b/Cork/Models/Brew Data Storage.swift
@@ -16,5 +16,5 @@ class BrewDataStorage: ObservableObject
 
 class AvailableTaps: ObservableObject
 {
-    @Published var tappedTaps = [BrewTap]()
+    @Published var addedTaps = [BrewTap]()
 }

--- a/Cork/Views/Sidebar/Sidebar View.swift
+++ b/Cork/Views/Sidebar/Sidebar View.swift
@@ -90,11 +90,11 @@ struct SidebarView: View
 
             if searchText.isEmpty
             {
-                Section("Tapped Taps")
+                Section("Added Taps")
                 {
-                    if availableTaps.tappedTaps.count != 0
+                    if availableTaps.addedTaps.count != 0
                     {
-                        ForEach(availableTaps.tappedTaps)
+                        ForEach(availableTaps.addedTaps)
                         { tap in
                             Text(tap.name)
                                 .contextMenu
@@ -103,15 +103,15 @@ struct SidebarView: View
                                     {
                                         Task(priority: .userInitiated)
                                         {
-                                            print("Would untap \(tap.name)")
-                                            try await untapATap(tapName: tap.name, availableTaps: availableTaps, appState: appState)
+                                            print("Would remove \(tap.name)")
+                                            try await removeTap(name: tap.name, availableTaps: availableTaps, appState: appState)
                                         }
                                     } label: {
-                                        Text("Untap \(tap.name)")
+                                        Text("Remove \(tap.name)")
                                     }
-                                    .alert(isPresented: $appState.isShowingUntappingFailedAlert, content: {
-                                        Alert(title: Text("Couldn't untap \(tap.name)"), message: Text("Try again in a few minutes, or restart Cork"), dismissButton: .default(Text("Close"), action: {
-                                            appState.isShowingUntappingFailedAlert = false
+                                    .alert(isPresented: $appState.isShowingRemoveTapFailedAlert, content: {
+                                        Alert(title: Text("Couldn't remove \(tap.name)"), message: Text("Try again in a few minutes, or restart Cork"), dismissButton: .default(Text("Close"), action: {
+                                            appState.isShowingRemoveTapFailedAlert = false
                                         }))
                                     })
                                 }

--- a/Cork/Views/Start Page/Start Page.swift
+++ b/Cork/Views/Start Page/Start Page.swift
@@ -109,8 +109,8 @@ struct StartPage: View
 
                                     GridRow(alignment: .firstTextBaseline)
                                     {
-                                        GroupBoxHeadlineGroup(title: "You have \(availableTaps.tappedTaps.count) Taps tapped", mainText: "Taps are sources of packages that are not provided by Homebrew itself")
-                                            .animation(.none, value: availableTaps.tappedTaps.count)
+                                        GroupBoxHeadlineGroup(title: "You have \(availableTaps.addedTaps.count) Taps added", mainText: "Taps are sources of packages that are not provided by Homebrew itself")
+                                            .animation(.none, value: availableTaps.addedTaps.count)
                                     }
                                 }
                             }

--- a/Cork/Views/Taps/Add Tap.swift
+++ b/Cork/Views/Taps/Add Tap.swift
@@ -45,7 +45,7 @@ struct AddTapView: View
             switch progress
             {
             case .ready:
-                SheetWithTitle(title: "Tap a tap")
+                SheetWithTitle(title: "Add a tap")
                 {
                     TextField("homebrew/core", text: $requestedTap)
                         .onSubmit
@@ -107,7 +107,7 @@ struct AddTapView: View
                 {
                     Task
                     {
-                        let tapResult = await tapAtap(tapName: requestedTap)
+                        let tapResult = await addTap(name: requestedTap)
 
                         print("Result: \(tapResult)")
 
@@ -134,16 +134,16 @@ struct AddTapView: View
                 ComplexWithIcon(systemName: "checkmark.seal") {
                     DisappearableSheet(isShowingSheet: $isShowingSheet)
                     {
-                        HeadlineWithSubheadline(headline: "Successfully tapped \(requestedTap)", subheadline: "There were no errors", alignment: .leading)
+                        HeadlineWithSubheadline(headline: "Successfully added \(requestedTap)", subheadline: "There were no errors", alignment: .leading)
                             .fixedSize(horizontal: true, vertical: true)
                             .onAppear
                             {
-                                availableTaps.tappedTaps.append(BrewTap(name: requestedTap))
+                                availableTaps.addedTaps.append(BrewTap(name: requestedTap))
                                 
                                 /// Remove that one element of the array that's empty for some reason
-                                availableTaps.tappedTaps.removeAll(where: { $0.name == "" })
+                                availableTaps.addedTaps.removeAll(where: { $0.name == "" })
                                 
-                                print("Available taps: \(availableTaps.tappedTaps)")
+                                print("Available taps: \(availableTaps.addedTaps)")
                             }
                     }
                 }


### PR DESCRIPTION
Change terminology to use 'tap' as a verb rather than both a verb and noun, to avoid the confusing phrase 'tap a tap'. [Homebrew's own documentation](https://docs.brew.sh/Taps) refers to tapping repositories so I think this is a safe and technically accurate change, and I'd argue it's more understandable even from an outside perspective.