### PR TITLE
+ Disable confirmation buttons when no action is possible

### DIFF
--- a/Cork/Views/Installation/Install Package.swift
+++ b/Cork/Views/Installation/Install Package.swift
@@ -58,6 +58,7 @@ struct AddFormulaView: View
                                 Text("Search")
                             }
                             .keyboardShortcut(.defaultAction)
+                            .disabled(packageRequested.isEmpty)
                         }
                     }
                 }
@@ -157,6 +158,7 @@ struct AddFormulaView: View
                                 Text("Install")
                             }
                             .keyboardShortcut(.defaultAction)
+                            .disabled(foundPackageSelection.isEmpty)
                         }
                     }
                 }

--- a/Cork/Views/Maintenance/Sub-Views/Ready View.swift
+++ b/Cork/Views/Maintenance/Sub-Views/Ready View.swift
@@ -83,6 +83,7 @@ struct MaintenanceReadyView: View {
                         Text("Start Maintenance")
                     }
                     .keyboardShortcut(.defaultAction)
+                    .disabled(isStartDisabled)
                 }
             }
         }
@@ -99,5 +100,9 @@ struct MaintenanceReadyView: View {
             }
             
         }
+    }
+
+    private var isStartDisabled: Bool {
+        [shouldUninstallOrphans, shouldPurgeCache, shouldDeleteDownloads, shouldPerformHealthCheck].allSatisfy { !$0 }
     }
 }

--- a/Cork/Views/Taps/Add Tap.swift
+++ b/Cork/Views/Taps/Add Tap.swift
@@ -92,9 +92,10 @@ struct AddTapView: View
                                 progress = .tapping
                             }
                         } label: {
-                            Text("Tap")
+                            Text("Add")
                         }
                         .keyboardShortcut(.defaultAction)
+                        .disabled(validateTapName(tapName: requestedTap) != nil)
                     }
                 }
 
@@ -187,16 +188,24 @@ struct AddTapView: View
         .padding()
     }
 
-    func checkIfTapNameIsValid(tapName: String)
-    {
+    private func validateTapName(tapName: String) -> TapInputErrors? {
         if tapName.isEmpty
         {
-            tapInputError = .empty
-            isShowingErrorPopover = true
+            return .empty
         }
         else if !tapName.contains("/")
         {
-            tapInputError = .missingSlash
+            return .missingSlash
+        }
+
+        return nil
+    }
+
+    private func checkIfTapNameIsValid(tapName: String)
+    {
+        if let error = validateTapName(tapName: tapName)
+        {
+            tapInputError = error
             isShowingErrorPopover = true
         }
     }


### PR DESCRIPTION
Disable confirmation buttons (add tap, install package, start maintenance, search) when no action is possible – for example, text field is empty, no package has been selected, or no maintenance options have been selected.