### PR TITLE
~ Fix caveats not rendering markdown (regression from #36)

### DIFF
--- a/Cork/Views/Packages/Package Details/Package Details.swift
+++ b/Cork/Views/Packages/Package Details/Package Details.swift
@@ -145,7 +145,11 @@ struct PackageDetailView: View
                                         /// Remove the last newline from the text if there is one, and replace all double newlines with a single newline
                                         VStack(alignment: .leading, spacing: 5) {
                                             let text = Text(
-                                                caveats.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "\n\n", with: "\n")
+                                                .init(
+                                                    caveats
+                                                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                                                        .replacingOccurrences(of: "\n\n", with: "\n")
+                                                )
                                             )
                                             .lineSpacing(5)
 


### PR DESCRIPTION
Fixes a regression from #36 in which package caveats text no longer rendered Markdown correctly.

Re-instates a call to the `LocalizedStringKey` initialiser (`.init(..)`) passing in the caveats text, in order to render Markdown. This was accidentally removed in my PR!