### PR TITLE
~ Use ellipsis to indicate actions that require confirmation/show further info

### DIFF
--- a/Cork/CorkApp.swift
+++ b/Cork/CorkApp.swift
@@ -64,7 +64,7 @@ struct CorkApp: App
                 {
                     appState.isShowingInstallationSheet.toggle()
                 } label: {
-                    Text("Install Packages")
+                    Text("Install Packages…")
                 }
                 .keyboardShortcut("n")
 
@@ -72,7 +72,7 @@ struct CorkApp: App
                 {
                     appState.isShowingAddTapSheet.toggle()
                 } label: {
-                    Text("Add a Tap")
+                    Text("Add a Tap…")
                 }
                 .keyboardShortcut("n", modifiers: [.command, .option])
 
@@ -102,7 +102,7 @@ struct CorkApp: App
                 {
                     appState.isShowingMaintenanceSheet.toggle()
                 } label: {
-                    Text("Perform Brew Maintenance")
+                    Text("Perform Brew Maintenance…")
                 }
                 .keyboardShortcut("m")
                 

--- a/Cork/Views/Maintenance/Sub-Views/Ready View.swift
+++ b/Cork/Views/Maintenance/Sub-Views/Ready View.swift
@@ -80,7 +80,7 @@ struct MaintenanceReadyView: View {
                         print("Start")
                         maintenanceSteps = .maintenanceRunning
                     } label: {
-                        Text("Start Maintenance")
+                        Text("Start")
                     }
                     .keyboardShortcut(.defaultAction)
                     .disabled(isStartDisabled)

--- a/Cork/Views/Start Page/Start Page.swift
+++ b/Cork/Views/Start Page/Start Page.swift
@@ -150,7 +150,7 @@ struct StartPage: View
                                             Button {
                                                 appState.isShowingFastCacheDeletionMaintenanceView = true
                                             } label: {
-                                                Text("Delete Cached Downloads")
+                                                Text("Delete Cached Downloads…")
                                             }
                                         }
                                     }
@@ -172,7 +172,7 @@ struct StartPage: View
                             print("Would perform maintenance")
                             appState.isShowingMaintenanceSheet.toggle()
                         } label: {
-                            Text("Brew Maintenance")
+                            Text("Brew Maintenance…")
                         }
                     }
                 }


### PR DESCRIPTION
Append an ellipsis to menu items and buttons which require confirmation or show further info before completing an action, as per Apple's Human Interface Guidelines (https://developer.apple.com/design/human-interface-guidelines/components/menus-and-actions/menus/#labels) (this is also more consistent with other macOS apps)