### PR TITLE
~ Use `secondary` instead of `gray` foreground color

### DIFF
--- a/Cork/Styles/DisclosureGroup - No Padding.swift
+++ b/Cork/Styles/DisclosureGroup - No Padding.swift
@@ -22,7 +22,7 @@ struct NoPadding: DisclosureGroupStyle
             {
                 Image(systemName: configuration.isExpanded ? "chevron.down" : "chevron.right")
                     .scaleEffect(0.8)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                     .symbolVariant(.fill)
 
                 configuration.label

--- a/Cork/Views/About/About View.swift
+++ b/Cork/Views/About/About View.swift
@@ -49,7 +49,7 @@ struct AboutView: View
 
                 Text("© 2022 David Bureš and contributors.")
                     .font(.subheadline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
 
                 VStack
                 {

--- a/Cork/Views/Loading View.swift
+++ b/Cork/Views/Loading View.swift
@@ -17,6 +17,6 @@ struct LoadingView: View
                 .scaleEffect(0.5)
             Text("Loading info...")
         }
-        .foregroundColor(.gray)
+        .foregroundColor(.secondary)
     }
 }

--- a/Cork/Views/Packages/Package Details/Package Details.swift
+++ b/Cork/Views/Packages/Package Details/Package Details.swift
@@ -53,7 +53,7 @@ struct PackageDetailView: View
                         .font(.title)
                     Text("v. \(returnFormattedVersions(package.versions))")
                         .font(.subheadline)
-                        .foregroundColor(.gray)
+                        .foregroundColor(.secondary)
                     
                     if pinned
                     {
@@ -67,7 +67,7 @@ struct PackageDetailView: View
                     HStack(alignment: .center, spacing: 5) {
                         if installedAsDependency
                         {
-                            OutlinedPillText(text: "Installed as a Dependency", color: .gray)
+                            OutlinedPillText(text: "Installed as a Dependency", color: .secondary)
                         }
                         if outdated
                         {

--- a/Cork/Views/Packages/Package List Item.swift
+++ b/Cork/Views/Packages/Package List Item.swift
@@ -20,7 +20,7 @@ struct PackageListItem: View
                 Text(packageItem.name)
                 Text(returnFormattedVersions(packageItem.versions))
                     .font(.subheadline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
             }
         }
     }

--- a/Cork/Views/Reusables/Complex with Icon.swift
+++ b/Cork/Views/Reusables/Complex with Icon.swift
@@ -20,7 +20,7 @@ struct ComplexWithIcon<Content: View>: View
             Image(systemName: systemName)
                 .resizable()
                 .frame(width: 50, height: 50)
-                .foregroundColor(.gray)
+                .foregroundColor(.secondary)
 
             content
         }

--- a/Cork/Views/Reusables/GroupBox Headline Group.swift
+++ b/Cork/Views/Reusables/GroupBox Headline Group.swift
@@ -30,7 +30,7 @@ struct GroupBoxHeadlineGroup: View
                 Text(title)
                 Text(mainText)
                     .font(.subheadline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
             }
         }
         .padding(10)


### PR DESCRIPTION
Use the `secondary` color instead of `gray` across the app, as `secondary` seems to adapt to the display context. For example, it adapts to a lighter variant when used in a selected sidebar item view, making the version number easier to read for a selected package.

| Before | After |
| -- | -- |
| ![Before](https://user-images.githubusercontent.com/379991/224560060-7eb91f04-4f15-4ff9-839b-b45600cf7a51.png) | ![After](https://user-images.githubusercontent.com/379991/224560067-dad3a744-4bc8-4850-b54e-510317e64b2e.png) |
