### PR TITLE
~ Use `transaction` to remove animation instead of deprecated `.animation(.none)`

### DIFF
--- a/Cork/Views/About/About View.swift
+++ b/Cork/Views/About/About View.swift
@@ -35,7 +35,7 @@ struct AboutView: View
             Image(nsImage: NSImage(named: "AppIcon") ?? NSImage())
                 .resizable()
                 .frame(width: 150, height: 150)
-                .animation(.none) // Has to be written this way to disable animations for when either of the dropdowns are disabled. If a value is provided, the animation will still play when the not-defined dropdown is toggled
+                .transaction { $0.animation = nil }
 
             VStack(alignment: .leading, spacing: 20)
             {
@@ -161,7 +161,7 @@ struct AboutView: View
                 }
             }
             .frame(width: 350, alignment: .topLeading)
-            .animation(.none) // See above
+            .transaction { $0.animation = nil }
         }
         .padding()
     }


### PR DESCRIPTION
Replaces the deprecated uses of the `animation` modifier without a value with `.transaction { $0.animation = nil }`