### PR TITLE
~ Use automatic grammar agreement where needed

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -37,7 +37,7 @@ struct ContentView: View
                     .frame(minWidth: 600, minHeight: 500)
             }
             .navigationTitle("Cork")
-            .navigationSubtitle("\(brewData.installedFormulae.count + brewData.installedCasks.count) packages installed")
+            .navigationSubtitle("^[\(brewData.installedFormulae.count + brewData.installedCasks.count) package](inflect: true) installed")
             .toolbar
             {
                 ToolbarItemGroup(placement: .primaryAction)

--- a/Cork/Views/Reusables/GroupBox Headline Group.swift
+++ b/Cork/Views/Reusables/GroupBox Headline Group.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct GroupBoxHeadlineGroup: View
 {
     var image: String?
-    let title: String
+    let title: LocalizedStringKey
     let mainText: String
 
     var body: some View

--- a/Cork/Views/Start Page/Start Page.swift
+++ b/Cork/Views/Start Page/Start Page.swift
@@ -131,7 +131,7 @@ struct StartPage: View
 
                                 GroupBoxHeadlineGroup(
                                     image: "macwindow",
-                                    title: "You have \(brewData.installedCasks.count) Casks installed",
+                                    title: "You have ^[\(brewData.installedCasks.count) Cask](inflect: true) installed",
                                     mainText: "Casks are packages that have graphical windows"
                                 )
                                 .animation(.none, value: brewData.installedCasks.count)
@@ -140,7 +140,7 @@ struct StartPage: View
 
                                 GroupBoxHeadlineGroup(
                                     image: "spigot",
-                                    title: "You have \(availableTaps.addedTaps.count) Taps added",
+                                    title: "You have ^[\(availableTaps.addedTaps.count) Tap](inflect: true) added",
                                     mainText: "Taps provide additional packages"
                                 )
                                 .animation(.none, value: availableTaps.addedTaps.count)


### PR DESCRIPTION
Use automatic grammar agreement to automatically determine the correct word (for example, singular 'cask' or plural 'casks') in several strings. (Thanks Paul Hudson! https://www.youtube.com/shorts/EDd6Hr_F99o)

Ideally, strings would be extracted to a strings file and plurals file and fully localised, but this at least feels like a nice improvement.