### PR TITLE
~ Extract localizable strings for sidebar, settings, about, start, tap & maintenance

### DIFF
--- a/Cork.xcodeproj/project.pbxproj
+++ b/Cork.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		63D8C957287A1D0800483A52 /* Loading View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D8C956287A1D0800483A52 /* Loading View.swift */; };
 		63E41C2F29C50A480084E266 /* Package Updating Stages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6360355729BDE7BF00CC0760 /* Package Updating Stages.swift */; };
 		63E41C3129C527C20084E266 /* Array - Get Second to Last Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E41C3029C527C20084E266 /* Array - Get Second to Last Element.swift */; };
+		96B86AF529C6561E00844DF4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96B86AF729C6561E00844DF4 /* Localizable.strings */; };
+		96B86AFD29C66E6D00844DF4 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 96B86AFF29C66E6D00844DF4 /* Localizable.stringsdict */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -230,6 +232,8 @@
 		63D86EB129C0972A00AD64D2 /* Package Search Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package Search Token.swift"; sourceTree = "<group>"; };
 		63D8C956287A1D0800483A52 /* Loading View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loading View.swift"; sourceTree = "<group>"; };
 		63E41C3029C527C20084E266 /* Array - Get Second to Last Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array - Get Second to Last Element.swift"; sourceTree = "<group>"; };
+		96B86AF629C6561E00844DF4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		96B86AFE29C66E6D00844DF4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -363,6 +367,8 @@
 				6340657E2871AF68001A2178 /* App Constants.swift */,
 				63958CFC2877341F00E0B807 /* AppDelegate.swift */,
 				63A8746D29904A7F009F9533 /* App State.swift */,
+				96B86AF729C6561E00844DF4 /* Localizable.strings */,
+				96B86AFF29C66E6D00844DF4 /* Localizable.stringsdict */,
 			);
 			path = Cork;
 			sourceTree = "<group>";
@@ -820,6 +826,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				6340656C2871AA42001A2178 /* Preview Assets.xcassets in Resources */,
+				96B86AFD29C66E6D00844DF4 /* Localizable.stringsdict in Resources */,
+				96B86AF529C6561E00844DF4 /* Localizable.strings in Resources */,
 				634065692871AA42001A2178 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -941,6 +949,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		96B86AF729C6561E00844DF4 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				96B86AF629C6561E00844DF4 /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		96B86AFF29C66E6D00844DF4 /* Localizable.stringsdict */ = {
+			isa = PBXVariantGroup;
+			children = (
+				96B86AFE29C66E6D00844DF4 /* en */,
+			);
+			name = Localizable.stringsdict;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		6340656E2871AA42001A2178 /* Debug */ = {

--- a/Cork/AppDelegate.swift
+++ b/Cork/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let window = NSWindow()
 
             window.styleMask = styleMask
-            window.title = "About \(NSApplication.appName!)"
+            window.title = NSLocalizedString("about.title", comment: "")
             window.contentView = NSHostingView(rootView: AboutView())
 
             aboutWindowController = NSWindowController(window: window)

--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -36,8 +36,8 @@ struct ContentView: View
                 StartPage()
                     .frame(minWidth: 600, minHeight: 500)
             }
-            .navigationTitle("Cork")
-            .navigationSubtitle("\(brewData.installedFormulae.count + brewData.installedCasks.count) packages installed")
+            .navigationTitle("app-name")
+            .navigationSubtitle("navigation.installed-packages.count-\(brewData.installedFormulae.count + brewData.installedCasks.count)")
             .toolbar
             {
                 ToolbarItemGroup(placement: .primaryAction)
@@ -48,12 +48,12 @@ struct ContentView: View
                     } label: {
                         Label
                         {
-                            Text("Upgrade Packages")
+                            Text("navigation.upgrade-packages")
                         } icon: {
                             Image(systemName: "arrow.clockwise")
                         }
                     }
-                    .help("Upgrade installed packages")
+                    .help("navigation.upgrade-packages.help")
 
                     Spacer()
 
@@ -63,12 +63,12 @@ struct ContentView: View
                     } label: {
                         Label
                         {
-                            Text("Add Tap")
+                            Text("navigation.add-tap")
                         } icon: {
                             Image(systemName: "spigot")
                         }
                     }
-                    .help("Add a new tap")
+                    .help("navigation.add-tap.help")
 
                     Button
                     {
@@ -76,12 +76,12 @@ struct ContentView: View
                     } label: {
                         Label
                         {
-                            Text("Install package")
+                            Text("navigation.install-package")
                         } icon: {
                             Image(systemName: "plus")
                         }
                     }
-                    .help("Install a new package")
+                    .help("navigation.install-package.help")
                 }
             }
         }
@@ -143,7 +143,7 @@ struct ContentView: View
             UpdatePackagesView(isShowingSheet: $appState.isShowingUpdateSheet)
         }
         .alert(isPresented: $appState.isShowingUninstallationNotPossibleDueToDependencyAlert, content: {
-            Alert(title: Text("Could Not Uninstall"), message: Text("This package is a dependency of \(appState.offendingDependencyProhibitingUninstallation)"), dismissButton: .default(Text("Close"), action: {
+            Alert(title: Text("alert.unable-to-uninstall-dependency.title"), message: Text("alert.unable-to-uninstall-dependency.message-\(appState.offendingDependencyProhibitingUninstallation)"), dismissButton: .default(Text("action.close"), action: {
                 appState.isShowingUninstallationNotPossibleDueToDependencyAlert = false
             }))
         })

--- a/Cork/CorkApp.swift
+++ b/Cork/CorkApp.swift
@@ -47,7 +47,7 @@ struct CorkApp: App
                 {
                     appDelegate.showAboutPanel()
                 } label: {
-                    Text("About \(NSApplication.appName!)")
+                    Text("navigation.about")
                 }
             }
 
@@ -57,13 +57,13 @@ struct CorkApp: App
                 
             }
 
-            CommandMenu("Packages")
+            CommandMenu("navigation.menu.packages")
             {
                 Button
                 {
                     appState.isShowingInstallationSheet.toggle()
                 } label: {
-                    Text("Install Packages…")
+                    Text("navigation.menu.packages.install")
                 }
                 .keyboardShortcut("n")
 
@@ -71,7 +71,7 @@ struct CorkApp: App
                 {
                     appState.isShowingAddTapSheet.toggle()
                 } label: {
-                    Text("Add a Tap…")
+                    Text("navigation.menu.packages.add-tap")
                 }
                 .keyboardShortcut("n", modifiers: [.command, .option])
 
@@ -81,7 +81,7 @@ struct CorkApp: App
                 {
                     appState.isShowingUpdateSheet = true
                 } label: {
-                    Text("Update Packages")
+                    Text("navigation.menu.packages.update")
                 }
                 .keyboardShortcut("r")
 
@@ -95,13 +95,13 @@ struct CorkApp: App
                   */
             }
 
-            CommandMenu("Maintenance")
+            CommandMenu("navigation.menu.maintenance")
             {
                 Button
                 {
                     appState.isShowingMaintenanceSheet.toggle()
                 } label: {
-                    Text("Perform Maintenance…")
+                    Text("navigation.menu.maintenance.perform")
                 }
                 .keyboardShortcut("m")
                 
@@ -110,7 +110,7 @@ struct CorkApp: App
                     Button {
                         appState.isShowingFastCacheDeletionMaintenanceView.toggle()
                     } label: {
-                        Text("Delete Cached Downloads")
+                        Text("navigation.menu.maintenance.delete-cached-downloads")
                     }
                     .keyboardShortcut("m", modifiers: [.command, .option])
                 }

--- a/Cork/Models/Misc/Acknowledged Contributor.swift
+++ b/Cork/Models/Misc/Acknowledged Contributor.swift
@@ -6,13 +6,28 @@
 //
 
 import Foundation
+import SwiftUI
 
 struct AcknowledgedContributor: Identifiable
 {
     var id: UUID = .init()
 
-    let name: String
-    let reasonForAcknowledgement: String
-    let profileService: String
+    let name: LocalizedStringKey
+    let reasonForAcknowledgement: LocalizedStringKey
+    let profileService: ProfileService
     let profileURL: URL
+
+    enum ProfileService
+    {
+        case github, mastodon
+
+        var key: LocalizedStringKey
+        {
+            switch self
+            {
+            case .github: return "about.contributor.service.github"
+            case .mastodon: return "about.contributor.service.mastodon"
+            }
+        }
+    }
 }

--- a/Cork/Models/Misc/Used Package.swift
+++ b/Cork/Models/Misc/Used Package.swift
@@ -6,13 +6,14 @@
 //
 
 import Foundation
+import SwiftUI
 
 struct UsedPackage: Identifiable
 {
     var id: UUID = .init()
 
-    let name: String
-    let whyIsItUsed: String
+    let name: LocalizedStringKey
+    let whyIsItUsed: LocalizedStringKey
     let packageURL: URL
 }
 

--- a/Cork/Views/About/About View.swift
+++ b/Cork/Views/About/About View.swift
@@ -11,18 +11,51 @@ import SwiftUI
 struct AboutView: View
 {
     @State private var usedPackages: [UsedPackage] = [
-        UsedPackage(name: "DavidFoundation", whyIsItUsed: "My own package that provides some basic convenience features", packageURL: URL(string: "https://github.com/buresdv/DavidFoundation")!),
-        UsedPackage(name: "SwiftyJSON", whyIsItUsed: "I hate default JSON parsing in Swift. Why reinvent the wheel when you can just use a library to make it bearable?", packageURL: URL(string: "https://github.com/SwiftyJSON/SwiftyJSON")!)
+        UsedPackage(
+            name: "about.packages.1.name",
+            whyIsItUsed: "about.packages.1.purpose",
+            packageURL: URL(string: "https://github.com/buresdv/DavidFoundation")!
+        ),
+        UsedPackage(
+            name: "about.packages.2.name",
+            whyIsItUsed: "about.packages.2.purpose",
+            packageURL: URL(string: "https://github.com/SwiftyJSON/SwiftyJSON")!
+        )
     ]
 
     @State private var specialThanks: [AcknowledgedContributor] = [
-        AcknowledgedContributor(name: "Seb Jachec", reasonForAcknowledgement: "Implemented a function for getting real-time outputs of commands, making more than half of all features in Cork much faster", profileService: "GitHub", profileURL: URL(string: "https://github.com/sebj")!),
+        AcknowledgedContributor(
+            name: "about.thanks.1.name",
+            reasonForAcknowledgement: "about.thanks.1.purpose",
+            profileService: .github,
+            profileURL: URL(string: "https://github.com/sebj")!)
+        ,
     ]
     @State private var acknowledgedContributors: [AcknowledgedContributor] = [
-        AcknowledgedContributor(name: "Rob Napier", reasonForAcknowledgement: "Gave invaluable help with all sorts of problems, from async Swift to blocking package installations", profileService: "Mastodon", profileURL: URL(string: "https://elk.zone/mstdn.social/@cocoaphony@mastodon.social")!),
-        AcknowledgedContributor(name: "Łukasz Rutkowski", reasonForAcknowledgement: "Fixed many async and SwiftUI problems", profileService: "Mastodon", profileURL: URL(string: "https://elk.zone/mstdn.social/@luckkerr@mastodon.world")!),
-        AcknowledgedContributor(name: "Jierong Li", reasonForAcknowledgement: "Fixed package counts on the start page not updating", profileService: "Mastodon", profileURL: URL(string: "https://elk.zone/mstdn.social/@jierongli@mastodon.social")!),
-        AcknowledgedContributor(name: "Oscar Bazaldua", reasonForAcknowledgement: "Made the first approved pull request; fixed package counts, along with Jierong Li", profileService: "Mastodon", profileURL: URL(string: "https://elk.zone/mstdn.social/@oscb@hachyderm.io")!),
+        AcknowledgedContributor(
+            name: "about.contributors.1.name",
+            reasonForAcknowledgement: "about.contributors.1.purpose",
+            profileService: .mastodon,
+            profileURL: URL(string: "https://elk.zone/mstdn.social/@cocoaphony@mastodon.social")!
+        ),
+        AcknowledgedContributor(
+            name: "about.contributors.2.name",
+            reasonForAcknowledgement: "about.contributors.2.purpose",
+            profileService: .mastodon,
+            profileURL: URL(string: "https://elk.zone/mstdn.social/@luckkerr@mastodon.world")!
+        ),
+        AcknowledgedContributor(
+            name: "about.contributors.3.name",
+            reasonForAcknowledgement: "about.contributors.3.purpose",
+            profileService: .mastodon,
+            profileURL: URL(string: "https://elk.zone/mstdn.social/@jierongli@mastodon.social")!
+        ),
+        AcknowledgedContributor(
+            name: "about.contributors.4.name",
+            reasonForAcknowledgement: "about.contributors.4.purpose",
+            profileService: .mastodon,
+            profileURL: URL(string: "https://elk.zone/mstdn.social/@oscb@hachyderm.io")!
+        ),
     ]
 
     @State private var isPackageGroupExpanded: Bool = false
@@ -43,11 +76,11 @@ struct AboutView: View
                 {
                     Text(NSApplication.appName!)
                         .font(.title)
-                    Text("Version \(NSApplication.appVersion!) (\(NSApplication.buildVersion!))")
+                    Text("about.version-\(NSApplication.appVersion!)-\(NSApplication.buildVersion!)")
                         .font(.caption)
                 }
 
-                Text("© 2022 David Bureš and contributors.")
+                Text("about.copyright")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
 
@@ -79,7 +112,7 @@ struct AboutView: View
                             idealHeight: 100
                         )
                     } label: {
-                        Text("Packages Used")
+                        Text("about.packages")
                     }
                     .animation(.none, value: isPackageGroupExpanded)
 
@@ -87,7 +120,7 @@ struct AboutView: View
                     {
                         List
                         {
-                            Section("Special Thanks")
+                            Section("about.thanks")
                             {
                                 ForEach(specialThanks)
                                 { contributor in
@@ -103,12 +136,12 @@ struct AboutView: View
 
                                         Spacer()
 
-                                        ButtonThatOpensWebsites(websiteURL: contributor.profileURL, buttonText: contributor.profileService)
+                                        ButtonThatOpensWebsites(websiteURL: contributor.profileURL, buttonText: contributor.profileService.key)
                                     }
                                 }
                             }
 
-                            Section("Acknowledged Contributors")
+                            Section("about.contributors")
                             {
                                 ForEach(acknowledgedContributors)
                                 { contributor in
@@ -124,7 +157,7 @@ struct AboutView: View
 
                                         Spacer()
 
-                                        ButtonThatOpensWebsites(websiteURL: contributor.profileURL, buttonText: contributor.profileService)
+                                        ButtonThatOpensWebsites(websiteURL: contributor.profileURL, buttonText: contributor.profileService.key)
                                     }
                                 }
                             }
@@ -136,7 +169,7 @@ struct AboutView: View
                             idealHeight: 200
                         )
                     } label: {
-                        Text("Acknowledged Contributors")
+                        Text("about.contributors")
                     }
                     .animation(.none, value: isContributorGroupExpanded)
                 }
@@ -147,7 +180,7 @@ struct AboutView: View
                     {
                         NSWorkspace.shared.open(URL(string: "https://github.com/buresdv/Cork")!)
                     } label: {
-                        Label("Contribute", systemImage: "curlybraces")
+                        Label("about.contribute", systemImage: "curlybraces")
                     }
 
                     Spacer()
@@ -156,7 +189,7 @@ struct AboutView: View
                     {
                         NSWorkspace.shared.open(URL(string: "https://elk.zone/mstdn.social/@davidbures")!)
                     } label: {
-                        Label("Contact Me", systemImage: "paperplane")
+                        Label("about.contact", systemImage: "paperplane")
                     }
                 }
             }

--- a/Cork/Views/Installation/Install Package.swift
+++ b/Cork/Views/Installation/Install Package.swift
@@ -36,11 +36,11 @@ struct AddFormulaView: View
             switch packageInstallationProcessStep
             {
             case .ready:
-                SheetWithTitle(title: "Install packages")
+                SheetWithTitle(title: "add-package.title")
                 {
                     VStack
                     {
-                        TextField("Search for packages...", text: $packageRequested)
+                        TextField("add-package.search.prompt", text: $packageRequested)
                         { _ in
                             foundPackageSelection = Set<UUID>() // Clear all selected items when the user looks for a different package
                         }
@@ -55,7 +55,7 @@ struct AddFormulaView: View
                             {
                                 packageInstallationProcessStep = .searching
                             } label: {
-                                Text("Search")
+                                Text("add-package.search.action")
                             }
                             .keyboardShortcut(.defaultAction)
                             .disabled(packageRequested.isEmpty)
@@ -64,7 +64,7 @@ struct AddFormulaView: View
                 }
 
             case .searching:
-                ProgressView("Searching for \(packageRequested)...")
+                ProgressView("add-package.searching-\(packageRequested)")
                     .onAppear
                     {
                         Task
@@ -91,7 +91,7 @@ struct AddFormulaView: View
             case .presentingSearchResults:
                 VStack
                 {
-                    TextField("Search for packages...", text: $packageRequested)
+                    TextField("add-package.search.prompt", text: $packageRequested)
                     { _ in
                         foundPackageSelection = Set<UUID>() // Clear all selected items when the user looks for a different package
                     }
@@ -99,14 +99,14 @@ struct AddFormulaView: View
 
                     List(selection: $foundPackageSelection)
                     {
-                        Section("Found Formulae")
+                        Section("add-package.search.results.formulae")
                         {
                             ForEach(searchResultTracker.foundFormulae)
                             { formula in
                                 SearchResultRow(packageName: formula.name, isCask: formula.isCask)
                             }
                         }
-                        Section("Found Casks")
+                        Section("add-package.search.results.casks")
                         {
                             ForEach(searchResultTracker.foundCasks)
                             { cask in
@@ -129,7 +129,7 @@ struct AddFormulaView: View
                             {
                                 packageInstallationProcessStep = .searching
                             } label: {
-                                Text("Search")
+                                Text("add-package.search.action")
                             }
                             .keyboardShortcut(.defaultAction)
                         }
@@ -155,7 +155,7 @@ struct AddFormulaView: View
                                 
                                 packageInstallationProcessStep = .installing
                             } label: {
-                                Text("Install")
+                                Text("add-package.install.action")
                             }
                             .keyboardShortcut(.defaultAction)
                             .disabled(foundPackageSelection.isEmpty)
@@ -177,42 +177,42 @@ struct AddFormulaView: View
                                 switch packageBeingInstalled.installationStage
                                 {
                                     case .ready:
-                                        Text("Building Dependency Graph...")
+                                        Text("add-package.install.ready")
                                         
                                     // FORMULAE
                                     case .loadingDependencies:
-                                        Text("Loading Dependencies...")
+                                        Text("add-package.install.loading-dependencies")
                                         
                                     case .fetchingDependencies:
-                                        Text("Fetching Dependencies...")
+                                        Text("add-package.install.fetching-dependencies")
                                         
                                     case .installingDependencies:
-                                        Text("Installing Dependency \(installationProgressTracker.numberInLineOfPackageCurrentlyBeingInstalled)/\(installationProgressTracker.numberOfPackageDependencies)...")
+                                        Text("add-package.install.installing-dependencies-\(installationProgressTracker.numberInLineOfPackageCurrentlyBeingInstalled)-\(installationProgressTracker.numberOfPackageDependencies)")
                                         
                                     case .installingPackage:
-                                        Text("Installing Package...")
+                                        Text("add-package.install.installing-package")
                                         
                                     case .finished:
-                                        Text("Done!")
+                                        Text("add-package.install.finished")
                                         
                                     // CASKS
                                     case .downloadingCask:
-                                        Text("Downloading \(installationProgressTracker.packagesBeingInstalled[0].package.name)...")
+                                        Text("add-package.install.downloading-cask-\(installationProgressTracker.packagesBeingInstalled[0].package.name)")
                                         
                                     case .installingCask:
-                                        Text("Installing \(installationProgressTracker.packagesBeingInstalled[0].package.name)...")
+                                        Text("add-package.install.installing-cask-\(installationProgressTracker.packagesBeingInstalled[0].package.name)")
                                         
                                     case .linkingCaskBinary:
-                                        Text("Linking Binaries...")
+                                        Text("add-package.install.linking-cask-binary")
                                         
                                     case .movingCask:
-                                        Text("Moving \(installationProgressTracker.packagesBeingInstalled[0].package.name) into the Applications Directory...")
+                                        Text("add-package.install.moving-cask-\(installationProgressTracker.packagesBeingInstalled[0].package.name)")
                                 }
                             }
                         }
                         else
                         { // Show this when the installation is finished
-                            Text("Done")
+                            Text("add-package.install.finished")
                                 .onAppear
                             {
                                 packageInstallationProcessStep = .finished
@@ -237,7 +237,11 @@ struct AddFormulaView: View
                 DisappearableSheet(isShowingSheet: $isShowingSheet)
                 {
                     ComplexWithIcon(systemName: "checkmark.seal") {
-                        HeadlineWithSubheadline(headline: "Packages successfuly installed", subheadline: "There were no errors", alignment: .leading)
+                        HeadlineWithSubheadline(
+                            headline: "add-package.finished",
+                            subheadline: "add-package.finished.description",
+                            alignment: .leading
+                        )
                     }
                 }
                 .onAppear

--- a/Cork/Views/Installation/Reusables/Search Result Row.swift
+++ b/Cork/Views/Installation/Reusables/Search Result Row.swift
@@ -30,14 +30,14 @@ struct SearchResultRow: View
                 {
                     if brewData.installedFormulae.contains(where: { $0.name == packageName })
                     {
-                        PillText(text: "Already Installed")
+                        PillText(text: "add-package.result.already-installed")
                     }
                 }
                 else
                 {
                     if brewData.installedCasks.contains(where: { $0.name == packageName })
                     {
-                        PillText(text: "Already Installed")
+                        PillText(text: "add-package.result.already-installed")
                     }
                 }
             }
@@ -51,7 +51,7 @@ struct SearchResultRow: View
                 }
                 else
                 {
-                    Text("Loading description...")
+                    Text("add-package.result.loading-description")
                         .font(.caption)
                         .foregroundColor(Color(nsColor: NSColor.systemGray))
                 }

--- a/Cork/Views/Maintenance/Maintenance View.swift
+++ b/Cork/Views/Maintenance/Maintenance View.swift
@@ -26,7 +26,7 @@ struct MaintenanceView: View
 
     @State var maintenanceSteps: MaintenanceSteps = .ready
 
-    @State var currentMaintenanceStepText: String = "Firing up..."
+    @State var currentMaintenanceStepText: LocalizedStringKey = "maintenance.step.initial"
 
     @State var shouldPurgeCache: Bool = true
     @State var shouldDeleteDownloads: Bool = true
@@ -37,7 +37,7 @@ struct MaintenanceView: View
 
     @State var cachePurgingSkippedPackagesDueToMostRecentVersionsNotBeingInstalled: Bool = false
     @State var packagesHoldingBackCachePurgeTracker: [String] = .init()
-    
+
     @State var brewHealthCheckFoundNoProblems: Bool = false
 
     @State var maintenanceFoundNoProblems: Bool = true
@@ -53,7 +53,7 @@ struct MaintenanceView: View
             switch maintenanceSteps
             {
             case .ready:
-                SheetWithTitle(title: "Maintenance")
+                SheetWithTitle(title: "maintenance.title")
                 {
                     MaintenanceReadyView(shouldUninstallOrphans: $shouldUninstallOrphans, shouldPurgeCache: $shouldPurgeCache, shouldDeleteDownloads: $shouldDeleteDownloads, shouldPerformHealthCheck: $shouldPerformHealthCheck, isShowingSheet: $isShowingSheet, maintenanceSteps: $maintenanceSteps, isShowingControlButtons: true, forcedOptions: forcedOptions!)
                 }
@@ -69,7 +69,7 @@ struct MaintenanceView: View
                             {
                                 if shouldUninstallOrphans
                                 {
-                                    currentMaintenanceStepText = "Uninstalling Orphans..."
+                                    currentMaintenanceStepText = "maintenance.step.removing-orphans"
 
                                     do
                                     {
@@ -93,7 +93,7 @@ struct MaintenanceView: View
 
                                 if shouldPurgeCache
                                 {
-                                    currentMaintenanceStepText = "Purging Cache..."
+                                    currentMaintenanceStepText = "maintenance.step.purging-cache"
 
                                     let cachePurgeOutput = try await purgeBrewCache()
                                     print("Cache purge output: \(cachePurgeOutput)")
@@ -130,7 +130,7 @@ struct MaintenanceView: View
                                 {
                                     print("Will delete downloads")
                                     
-                                    currentMaintenanceStepText = "Deleting cached downloads..."
+                                    currentMaintenanceStepText = "maintenance.step.deleting-cached-downloads"
                                     
                                     deleteCachedDownloads()
                                     
@@ -144,7 +144,7 @@ struct MaintenanceView: View
 
                                 if shouldPerformHealthCheck
                                 {
-                                    currentMaintenanceStepText = "Running Health Check..."
+                                    currentMaintenanceStepText = "maintenance.step.running-health-check"
 
                                     do
                                     {
@@ -177,18 +177,18 @@ struct MaintenanceView: View
                     {
                         VStack(alignment: .leading, spacing: 5)
                         {
-                            Text("Maintenance finished")
+                            Text("maintenance.finished")
                                 .font(.headline)
 
                             if shouldUninstallOrphans
                             {
                                 if numberOfOrphansRemoved == 0
                                 {
-                                    Text("No orphaned packages found")
+                                    Text("maintenance.results.orphans-none")
                                 }
                                 else
                                 {
-                                    Text("\(numberOfOrphansRemoved) orphaned packages removed")
+                                    Text("maintenance.results.orphans-\(numberOfOrphansRemoved)")
                                 }
                             }
 
@@ -196,13 +196,13 @@ struct MaintenanceView: View
                             {
                                 VStack(alignment: .leading)
                                 {
-                                    Text("Package cache purged")
+                                    Text("maintenance.results.package-cache")
 
                                     if cachePurgingSkippedPackagesDueToMostRecentVersionsNotBeingInstalled
                                     {
                                         Text(packagesHoldingBackCachePurgeTracker.count > 2 ?
-                                             "Some caches weren't purged because of \(packagesHoldingBackCachePurgeTracker[0...1].joined(separator: ", ")) and \(packagesHoldingBackCachePurgeTracker.count - 2) others not being updated" :
-                                                "Some caches weren't purged because of \(packagesHoldingBackCachePurgeTracker.joined(separator: ", ")) not being updated")
+                                             "maintenance.results.package-cache.skipped-\(packagesHoldingBackCachePurgeTracker[0...1].joined(separator: ", "))-and-\(packagesHoldingBackCachePurgeTracker.count - 2)-others" :
+                                                "maintenance.results.package-cache.skipped- \(packagesHoldingBackCachePurgeTracker.joined(separator: ", "))")
                                             .font(.caption)
                                             .foregroundColor(Color(nsColor: NSColor.systemGray))
                                     }
@@ -212,8 +212,8 @@ struct MaintenanceView: View
                             if shouldDeleteDownloads
                             {
                                 VStack(alignment: .leading) {
-                                    Text("Cached downloads deleted")
-                                    Text("You reclaimed \(reclaimedSpaceAfterCachePurge.formatted(.byteCount(style: .file)))")
+                                    Text("maintenance.results.cached-downloads")
+                                    Text("maintenance.results.cached-downloads.summary-\(reclaimedSpaceAfterCachePurge.formatted(.byteCount(style: .file)))")
                                         .font(.caption)
                                         .foregroundColor(Color(nsColor: NSColor.systemGray))
                                 }
@@ -223,11 +223,11 @@ struct MaintenanceView: View
                             {
                                 if brewHealthCheckFoundNoProblems
                                 {
-                                    Text("No problems with Homebrew found")
+                                    Text("maintenance.results.health-check.problems-none")
                                 }
                                 else
                                 {
-                                    Text("Found some problems with Homebrew")
+                                    Text("maintenance.results.health-check.problems")
                                         .onAppear
                                         {
                                             maintenanceFoundNoProblems = false
@@ -248,7 +248,7 @@ struct MaintenanceView: View
                                 
                                 appState.cachedDownloadsFolderSize = directorySize(url: AppConstants.brewCachedDownloadsPath)
                             } label: {
-                                Text("Close")
+                                Text("action.close")
                             }
                             .keyboardShortcut(.defaultAction)
                         }

--- a/Cork/Views/Maintenance/Sub-Views/Ready View.swift
+++ b/Cork/Views/Maintenance/Sub-Views/Ready View.swift
@@ -32,37 +32,37 @@ struct MaintenanceReadyView: View {
         {
             Form
             {
-                LabeledContent("Packages:")
+                LabeledContent("maintenance.steps.packages")
                 {
                     VStack(alignment: .leading)
                     {
                         Toggle(isOn: $shouldUninstallOrphans)
                         {
-                            Text("Uninstall orphaned packages")
+                            Text("maintenance.steps.packages.uninstall-orphans")
                         }
                     }
                 }
 
-                LabeledContent("Downloads:")
+                LabeledContent("maintenance.steps.downloads")
                 {
                     VStack(alignment: .leading)
                     {
                         Toggle(isOn: $shouldPurgeCache)
                         {
-                            Text("Purge Homebrew cache")
+                            Text("maintenance.steps.downloads.purge-cache")
                         }
                         Toggle(isOn: $shouldDeleteDownloads)
                         {
-                            Text("Delete cached downloads")
+                            Text("maintenance.steps.downloads.delete-cached-downloads")
                         }
                     }
                 }
 
-                LabeledContent("Other:")
+                LabeledContent("maintenance.steps.other")
                 {
                     Toggle(isOn: $shouldPerformHealthCheck)
                     {
-                        Text("Perform health check")
+                        Text("maintenance.steps.other.health-check")
                     }
                 }
             }
@@ -80,7 +80,7 @@ struct MaintenanceReadyView: View {
                         print("Start")
                         maintenanceSteps = .maintenanceRunning
                     } label: {
-                        Text("Start")
+                        Text("maintenance.steps.start")
                     }
                     .keyboardShortcut(.defaultAction)
                     .disabled(isStartDisabled)

--- a/Cork/Views/Misc/Button That Opens Websites.swift
+++ b/Cork/Views/Misc/Button That Opens Websites.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct ButtonThatOpensWebsites: View
 {
     @State var websiteURL: URL
-    @State var buttonText: String
+    @State var buttonText: LocalizedStringKey
 
     var body: some View
     {

--- a/Cork/Views/Packages/Package Details/Package Details.swift
+++ b/Cork/Views/Packages/Package Details/Package Details.swift
@@ -59,7 +59,7 @@ struct PackageDetailView: View
                     if pinned
                     {
                         Image(systemName: "pin.fill")
-                            .help("\(package.name) is pinned. It will not be updated.")
+                            .help("package-details.pinned.help-\(package.name)")
                     }
                 }
 
@@ -73,7 +73,7 @@ struct PackageDetailView: View
                             {
                                 if packageDependents.count != 0 // This happens when the package was originally installed as a dependency, but the parent is no longer installed
                                 {
-                                    OutlinedPillText(text: "Dependency of \(packageDependents.joined(separator: ", "))", color: .secondary)
+                                    OutlinedPillText(text: "package-details.dependants.dependency-of-\(packageDependents.joined(separator: ", "))", color: .secondary)
                                 }
                             }
                             else
@@ -85,14 +85,14 @@ struct PackageDetailView: View
                                             .scaleEffect(0.3, anchor: .center)
                                             .frame(width: 5, height: 5)
 
-                                        Text("Loading Dependants...")
+                                        Text("package-details.dependants.loading")
                                     }
                                 }, color: Color(nsColor: NSColor.tertiaryLabelColor))
                             }
                         }
                         if outdated
                         {
-                            OutlinedPillText(text: "Outdated", color: .orange)
+                            OutlinedPillText(text: "package-details.outdated", color: .orange)
                         }
                         if let caveats
                         {
@@ -100,7 +100,7 @@ struct PackageDetailView: View
                             {
                                 if caveatDisplayOptions == .mini
                                 {
-                                    OutlinedPillText(text: "Has caveats 􀅴", color: .indigo)
+                                    OutlinedPillText(text: "package-details.caveats.available", color: .indigo)
                                         .onTapGesture
                                         {
                                             isShowingCaveatPopover.toggle()
@@ -111,7 +111,7 @@ struct PackageDetailView: View
                                                 .textSelection(.enabled)
                                                 .lineSpacing(5)
                                                 .padding()
-                                                .help("Click to see caveats")
+                                                .help("package-details.caveats.help")
                                         }
                                 }
                             }
@@ -133,7 +133,7 @@ struct PackageDetailView: View
                                     .resizable()
                                     .frame(width: 15, height: 15)
                                     .foregroundColor(.yellow)
-                                Text("\(package.name) has no description")
+                                Text("package-details.description-none-\(package.name)")
                                     .font(.subheadline)
                             }
                         }
@@ -149,7 +149,7 @@ struct PackageDetailView: View
                     {
                         ProgressView
                         {
-                            Text("Loading package info...")
+                            Text("package-details.contents.loading")
                         }
                     }
                 }
@@ -159,7 +159,7 @@ struct PackageDetailView: View
             {
                 VStack(alignment: .leading, spacing: 10)
                 {
-                    Text("Info")
+                    Text("package-details.info")
                         .font(.title2)
 
                     if let caveats
@@ -211,7 +211,7 @@ struct PackageDetailView: View
                                                         isShowingExpandedCaveats.toggle()
                                                     }
                                                 } label: {
-                                                    Text(isShowingExpandedCaveats ? "Collapse" : "Expand")
+                                                    Text(isShowingExpandedCaveats ? "package-details.caveats.collapse" : "package-details.caveats.expand")
                                                 }
                                                 .padding(.top, 5)
                                             }
@@ -238,14 +238,14 @@ struct PackageDetailView: View
 
                             GridRow(alignment: .top)
                             {
-                                Text("Type")
+                                Text("package-details.type")
                                 if package.isCask
                                 {
-                                    Text("Cask")
+                                    Text("package-details.type.cask")
                                 }
                                 else
                                 {
-                                    Text("Formula")
+                                    Text("package-details.type.formula")
                                 }
                             }
 
@@ -253,7 +253,7 @@ struct PackageDetailView: View
 
                             GridRow(alignment: .top)
                             {
-                                Text("Homepage")
+                                Text("package-details.homepage")
                                 Link(destination: homepage)
                                 {
                                     Text(homepage.absoluteString)
@@ -268,7 +268,7 @@ struct PackageDetailView: View
                         {
                             VStack
                             {
-                                DisclosureGroup("Dependencies", isExpanded: $isShowingDependencies)
+                                DisclosureGroup("package-details.dependencies", isExpanded: $isShowingDependencies)
                                 {}
                                 .disclosureGroupStyle(NoPadding())
 
@@ -288,7 +288,7 @@ struct PackageDetailView: View
                             {
                                 GridRow(alignment: .top)
                                 {
-                                    Text("Installed On")
+                                    Text("package-details.install-date")
                                     Text(installedOnDate.formatted(.packageInstallationStyle))
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                 }
@@ -299,7 +299,7 @@ struct PackageDetailView: View
 
                                     GridRow(alignment: .top)
                                     {
-                                        Text("Size")
+                                        Text("package-details.size")
 
                                         HStack
                                         {
@@ -311,15 +311,15 @@ struct PackageDetailView: View
                                                 {
                                                     isShowingPopover.toggle()
                                                 }
-                                                .help("Why is the size so small?")
+                                                .help("package-details.size.help")
                                                 .popover(isPresented: $isShowingPopover)
                                                 {
                                                     VStack(alignment: .leading, spacing: 10)
                                                     {
-                                                        Text("Why is the size so small?")
+                                                        Text("package-details.size.help.title")
                                                             .font(.headline)
-                                                        Text("Casks are not installed into the same installation directory as Formulae. Casks are installed into the Applications directory.")
-                                                        Text("Since Cork does not have access to your Applications directory, it cannot get the size of the actual app, only of the metadata associated with the Cask.")
+                                                        Text("package-details.size.help.body-1")
+                                                        Text("package-details.size.help.body-2")
                                                     }
                                                     .padding()
                                                     .frame(width: 300, alignment: .center)
@@ -353,7 +353,7 @@ struct PackageDetailView: View
                                     await pinAndUnpinPackage(package: package, pinned: pinned)
                                 }
                             } label: {
-                                Text(pinned ? "Unpin from version \(package.versions.joined())" : "Pin to version \(package.versions.joined())")
+                                Text(pinned ? "package-details.action.unpin-version-\(package.versions.joined())" : "package-details.action.pin-version-\(package.versions.joined())")
                             }
                         }
 
@@ -370,7 +370,7 @@ struct PackageDetailView: View
                                     try await uninstallSelectedPackage(package: package, brewData: brewData, appState: appState)
                                 }
                             } label: {
-                                Text("Uninstall \(package.name)")
+                                Text("package-details.action.uninstall-\(package.name)")
                             }
                         }
                     }

--- a/Cork/Views/Packages/Package Details/Sub-Views/Dependency List.swift
+++ b/Cork/Views/Packages/Package Details/Sub-Views/Dependency List.swift
@@ -34,30 +34,30 @@ struct DependencyList: View
         {
             if showSearchFieldForDependenciesInPackageDetails
             {
-                CustomSearchField(search: $dependencySearchText, customPromptText: "Dependencies")
+                CustomSearchField(search: $dependencySearchText, customPromptText: "package-details.dependencies.search.prompt")
             }
 
             if displayAdvancedDependencies
             {
                 Table(foundDependencies)
                 {
-                    TableColumn("Name")
+                    TableColumn("package-details.dependencies.results.name")
                     { dependency in
                         Text(dependency.name)
                     }
-                    TableColumn("Version")
+                    TableColumn("package-details.dependencies.results.version")
                     { dependency in
                         Text(dependency.version)
                     }
-                    TableColumn("Declaration Type")
+                    TableColumn("package-details.dependencies.results.declaration")
                     { dependency in
                         if dependency.directlyDeclared
                         {
-                            Text("Direct")
+                            Text("package-details.dependencies.results.declaration.direct")
                         }
                         else
                         {
-                            Text("Indirect")
+                            Text("package-details.dependencies.results.declaration.indirect")
                         }
                     }
                 }

--- a/Cork/Views/PillText.swift
+++ b/Cork/Views/PillText.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PillText: View
 {
-    @State var text: String
+    @State var text: LocalizedStringKey
     var body: some View
     {
         Text(text)
@@ -23,7 +23,7 @@ struct PillText: View
 
 struct OutlinedPillText: View
 {
-    @State var text: String
+    @State var text: LocalizedStringKey
     @State var color: Color
     
     var body: some View

--- a/Cork/Views/Reusables/Custom Search Field.swift
+++ b/Cork/Views/Reusables/Custom Search Field.swift
@@ -40,7 +40,7 @@ struct CustomSearchField: NSViewRepresentable
 
         if let customPromptText
         {
-            searchField.placeholderString = customPromptText
+            searchField.placeholderString = NSLocalizedString(customPromptText, comment: "")
         }
 
         return searchField

--- a/Cork/Views/Reusables/GroupBox Headline Group.swift
+++ b/Cork/Views/Reusables/GroupBox Headline Group.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct GroupBoxHeadlineGroup: View
 {
     var image: String?
-    let title: String
-    let mainText: String
+    let title: LocalizedStringKey
+    let mainText: LocalizedStringKey
 
     var body: some View
     {

--- a/Cork/Views/Reusables/Headline with Subheadline.swift
+++ b/Cork/Views/Reusables/Headline with Subheadline.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct HeadlineWithSubheadline: View
 {
-    @State var headline: String
-    @State var subheadline: String
+    @State var headline: LocalizedStringKey
+    @State var subheadline: LocalizedStringKey
 
     @State var alignment: HorizontalAlignment
 

--- a/Cork/Views/Reusables/Sheets/Components/Dismiss Sheet Button.swift
+++ b/Cork/Views/Reusables/Sheets/Components/Dismiss Sheet Button.swift
@@ -24,7 +24,7 @@ struct DismissSheetButton: View
             }
             else
             {
-                Text("Cancel")
+                Text("action.cancel")
             }
         }
         .keyboardShortcut(.cancelAction)

--- a/Cork/Views/Reusables/Sheets/Sheet with Title.swift
+++ b/Cork/Views/Reusables/Sheets/Sheet with Title.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SheetWithTitle<Content: View>: View
 {
-    @State var title: String
+    @State var title: LocalizedStringKey
 
     @ViewBuilder var sheetContent: Content
 

--- a/Cork/Views/Settings/Panes/General Pane.swift
+++ b/Cork/Views/Settings/Panes/General Pane.swift
@@ -25,24 +25,24 @@ struct GeneralPane: View
             {
                 Picker(selection: $sortPackagesBy)
                 {
-                    Text("Name")
+                    Text("settings.general.sort-packages.alphabetically")
                         .tag(PackageSortingOptions.alphabetically)
-                    Text("Installation Date")
+                    Text("settings.general.sort-packages.install-date")
                         .tag(PackageSortingOptions.byInstallDate)
-                    Text("Size")
+                    Text("settings.general.sort-packages.size")
                         .tag(PackageSortingOptions.bySize)
 
                     Divider()
 
-                    Text("Do Not Sort")
+                    Text("settings.general.sort-packages.none")
                         .tag(PackageSortingOptions.none)
                 } label: {
-                    Text("Sort packages by:")
+                    Text("settings.general.sort-packages")
                 }
 
                 if sortPackagesBy == .none
                 {
-                    Text("􀅴 Restart Cork for this sorting option to take effect")
+                    Text("settings.general.sort-packages.restart")
                         .font(.caption)
                         .foregroundColor(Color(nsColor: NSColor.systemGray))
                 }
@@ -53,18 +53,18 @@ struct GeneralPane: View
                     {
                         Toggle(isOn: $displayAdvancedDependencies)
                         {
-                            Text("Show more info about dependecies")
+                            Text("settings.general.dependencies.toggle")
                         }
                     }
                 } label: {
-                    Text("Dependencies:")
+                    Text("settings.general.dependencies")
                 }
 
                 Picker(selection: $caveatDisplayOptions)
                 {
-                    Text("Full")
+                    Text("settings.general.package-caveats.full")
                         .tag(PackageCaveatDisplay.full)
-                    Text("Minified")
+                    Text("settings.general.package-caveats.minified")
                         .tag(PackageCaveatDisplay.mini)
                 } label: {
                     Text("Package caveats:")
@@ -72,7 +72,7 @@ struct GeneralPane: View
                 .pickerStyle(.radioGroup)
                 if caveatDisplayOptions == .mini
                 {
-                    Text("􀅴 Click on the \"Has caveats\" pill to see the caveats")
+                    Text("settings.general.package-caveats.minified.info")
                         .font(.caption)
                         .foregroundColor(Color(nsColor: NSColor.systemGray))
                 }
@@ -81,16 +81,16 @@ struct GeneralPane: View
                 {
                     Toggle(isOn: $showDescriptionsInSearchResults)
                     {
-                        Text("Show package descriptions")
+                        Text("settings.general.search-results.toggle")
                     }
                 } label: {
-                    Text("Search results:")
+                    Text("settings.general.search-results")
                 }
 
                 LabeledContent
                 {
                     Toggle(isOn: $showSearchFieldForDependenciesInPackageDetails) {
-                        Text("Show search field for dependencies")
+                        Text("settings.general.package-details.toggle")
                     }
                 } label: {
                     Text("Package details:")

--- a/Cork/Views/Settings/Panes/Installation Pane.swift
+++ b/Cork/Views/Settings/Panes/Installation Pane.swift
@@ -24,10 +24,10 @@ struct InstallationAndUninstallationPane: View
                 {
                     Toggle(isOn: $showPackagesStillLeftToInstall)
                     {
-                        Text("Show list of packages currently being installed")
+                        Text("settings.install-uninstall.installation.toggle")
                     }
                 } label: {
-                    Text("Installation:")
+                    Text("settings.install-uninstall.installation")
                 }
 
                 LabeledContent
@@ -36,15 +36,15 @@ struct InstallationAndUninstallationPane: View
                     {
                         Toggle(isOn: $purgeCacheAfterEveryUninstallation)
                         {
-                            Text("Purge cache after uninstalling packages")
+                            Text("settings.install-uninstall.uninstallation.purge-cache")
                         }
                         Toggle(isOn: $removeOrphansAfterEveryUninstallation)
                         {
-                            Text("Remove orphans after uninstalling packages")
+                            Text("settings.install-uninstall.uninstallation.remove-orphans")
                         }
                     }
                 } label: {
-                    Text("Uninstallation:")
+                    Text("settings.install-uninstall.uninstallation")
                 }
             }
         }

--- a/Cork/Views/Settings/Panes/Maintenance Pane.swift
+++ b/Cork/Views/Settings/Panes/Maintenance Pane.swift
@@ -23,7 +23,7 @@ struct MaintenancePane: View
         {
             VStack(alignment: .leading, spacing: 10)
             {
-                Text("Set default steps")
+                Text("settings.maintenance.default-steps")
                     .font(.headline)
                 MaintenanceReadyView(shouldUninstallOrphans: $default_shouldUninstallOrphans, shouldPurgeCache: $default_shouldPurgeCache, shouldDeleteDownloads: $default_shouldDeleteDownloads, shouldPerformHealthCheck: $default_shouldPerformHealthCheck, isShowingSheet: $isShowingSheetDummy, maintenanceSteps: $maintenanceStepsDummy, isShowingControlButtons: false, forcedOptions: false)
             }

--- a/Cork/Views/Settings/Settings View.swift
+++ b/Cork/Views/Settings/Settings View.swift
@@ -16,23 +16,23 @@ struct SettingsView: View
             GeneralPane()
                 .tabItem
                 {
-                    Label("General", systemImage: "gearshape")
+                    Label("settings.general", systemImage: "gearshape")
                 }
 
             MaintenancePane()
                 .tabItem
                 {
-                    Label("Maintenance", systemImage: "arrow.3.trianglepath")
+                    Label("settings.maintenance", systemImage: "arrow.3.trianglepath")
                 }
 
             BrewPane()
                 .tabItem {
-                    Label("Homebrew", systemImage: "cup.and.saucer")
+                    Label("settings.homebrew", systemImage: "cup.and.saucer")
                 }
             /*InstallationAndUninstallationPane()
                 .tabItem
                 {
-                    Label("Install and Uninstall", systemImage: "plus")
+                    Label("settings.install-uninstall", systemImage: "plus")
                 }*/
         }
     }

--- a/Cork/Views/Sidebar/Sidebar View.swift
+++ b/Cork/Views/Sidebar/Sidebar View.swift
@@ -39,7 +39,7 @@ struct SidebarView: View
         {
             if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .formula })
             {
-                Section("Installed Formulae")
+                Section("sidebar.section.installed-formulae")
                 {
                     if !appState.isLoadingFormulae
                     {
@@ -60,7 +60,7 @@ struct SidebarView: View
                                         try await uninstallSelectedPackage(package: formula, brewData: brewData, appState: appState)
                                     }
                                 } label: {
-                                    Text("Uninstall \(formula.name)")
+                                    Text("sidebar.section.installed-formulae.contextmenu.uninstall-\(formula.name)")
                                 }
                             }
                         }
@@ -75,7 +75,7 @@ struct SidebarView: View
 
             if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .cask })
             {
-                Section("Installed Casks")
+                Section("sidebar.section.installed-casks")
                 {
                     if !appState.isLoadingCasks
                     {
@@ -96,7 +96,7 @@ struct SidebarView: View
                                         try await uninstallSelectedPackage(package: cask, brewData: brewData, appState: appState)
                                     }
                                 } label: {
-                                    Text("Uninstall \(cask.name)")
+                                    Text("sidebar.section.installed-casks.contextmenu.uninstall-\(cask.name)")
                                 }
                             }
                         }
@@ -111,7 +111,7 @@ struct SidebarView: View
 
             if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .tap })
             {
-                Section("Added Taps")
+                Section("sidebar.section.added-taps")
                 {
                     if availableTaps.addedTaps.count != 0
                     {
@@ -134,10 +134,10 @@ struct SidebarView: View
                                         try await removeTap(name: tap.name, availableTaps: availableTaps, appState: appState)
                                     }
                                 } label: {
-                                    Text("Remove \(tap.name)")
+                                    Text("sidebar.section.added-taps.contextmenu.remove-\(tap.name)")
                                 }
                                 .alert(isPresented: $appState.isShowingRemoveTapFailedAlert, content: {
-                                    Alert(title: Text("Couldn't remove \(tap.name)"), message: Text("Try again in a few minutes, or restart Cork"), dismissButton: .default(Text("Close"), action: {
+                                    Alert(title: Text("sidebar.section.added-taps.remove.title-\(tap.name)"), message: Text("sidebar.section.added-taps.remove.message"), dismissButton: .default(Text("action.close"), action: {
                                         appState.isShowingRemoveTapFailedAlert = false
                                     }))
                                 })
@@ -153,7 +153,7 @@ struct SidebarView: View
         }
         .listStyle(.sidebar)
         .frame(minWidth: 200)
-        .searchable(text: $searchText, tokens: $currentTokens, suggestedTokens: .constant(suggestedTokens), placement: .sidebar, prompt: Text("Installed Packages"))
+        .searchable(text: $searchText, tokens: $currentTokens, suggestedTokens: .constant(suggestedTokens), placement: .sidebar, prompt: Text("sidebar.search.prompt"))
         { token in
             Text(token.name)
         }

--- a/Cork/Views/Start Page/Start Page.swift
+++ b/Cork/Views/Start Page/Start Page.swift
@@ -31,7 +31,7 @@ struct StartPage: View
         {
             if appState.isLoadingFormulae && appState.isLoadingCasks || availableTaps.addedTaps.isEmpty
             {
-                ProgressView("Loading Packages...")
+                ProgressView("start-page.loading")
             }
             else
             {
@@ -39,7 +39,7 @@ struct StartPage: View
                 {
                     VStack(alignment: .leading)
                     {
-                        Text("Homebrew Status")
+                        Text("start-page.status")
                             .font(.title)
                             .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
 
@@ -54,7 +54,7 @@ struct StartPage: View
                                         {
                                             ProgressView()
 
-                                            Text("Checking for package updates...")
+                                            Text("start-page.updates.loading")
                                         }
                                         .padding(10)
                                     }
@@ -79,11 +79,11 @@ struct StartPage: View
                                                 HStack(alignment: .firstTextBaseline)
                                                 {
                                                     VStack(alignment: .leading, spacing: 2) {
-                                                        Text(outdatedPackageTracker.outdatedPackageNames.count == 1 ? "There is 1 outdated package" : "There are \(outdatedPackageTracker.outdatedPackageNames.count) outdated packages")
+                                                        Text("start-page.updates.count-\(outdatedPackageTracker.outdatedPackageNames.count)")
                                                             .font(.headline)
                                                         DisclosureGroup(isExpanded: $isDisclosureGroupExpanded)
                                                         {} label: {
-                                                            Text("Outdated packages")
+                                                            Text("start-page.updates.list")
                                                                 .font(.subheadline)
                                                         }
 
@@ -106,7 +106,7 @@ struct StartPage: View
                                                     {
                                                         appState.isShowingUpdateSheet = true
                                                     } label: {
-                                                        Text("Update")
+                                                        Text("start-page.updates.action")
                                                     }
                                                 }
                                             }
@@ -122,8 +122,8 @@ struct StartPage: View
                             {
                                 GroupBoxHeadlineGroup(
                                     image: "terminal",
-                                    title: "You have \(brewData.installedFormulae.count) Formulae installed",
-                                    mainText: "Formulae are packages that you use through a terminal"
+                                    title: "start-page.installed-formulae.count-\(brewData.installedFormulae.count)",
+                                    mainText: "start-page.installed-formulae.description"
                                 )
                                 .animation(.none, value: brewData.installedFormulae.count)
 
@@ -131,8 +131,8 @@ struct StartPage: View
 
                                 GroupBoxHeadlineGroup(
                                     image: "macwindow",
-                                    title: "You have \(brewData.installedCasks.count) Casks installed",
-                                    mainText: "Casks are packages that have graphical windows"
+                                    title: "start-page.installed-casks.count-\(brewData.installedCasks.count)",
+                                    mainText: "start-page.installed-casks.description"
                                 )
                                 .animation(.none, value: brewData.installedCasks.count)
 
@@ -140,8 +140,8 @@ struct StartPage: View
 
                                 GroupBoxHeadlineGroup(
                                     image: "spigot",
-                                    title: "You have \(availableTaps.addedTaps.count) Taps added",
-                                    mainText: "Taps provide additional packages"
+                                    title: "start-page.added-taps.count-\(availableTaps.addedTaps.count)",
+                                    mainText: "start-page.added-taps.description"
                                 )
                                 .animation(.none, value: availableTaps.addedTaps.count)
                             }
@@ -153,8 +153,8 @@ struct StartPage: View
                             {
                                 GroupBoxHeadlineGroup(
                                     image: "chart.bar",
-                                    title: "Homebrew analytics are \(allowBrewAnalytics ? "enabled" : "disabled")",
-                                    mainText: "\(allowBrewAnalytics ? "Homebrew is collecting various anonymized data, such as which packages you have installed" : "Homebrew is not collecting any data about how you use it")"
+                                    title: allowBrewAnalytics ? "start-page.analytics.enabled" : "start-page.analytics.disabled",
+                                    mainText: allowBrewAnalytics ? "start-page.analytics.enabled.description" : "start-page.analytics.disabled.description"
                                 )
                                 .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             }
@@ -170,8 +170,8 @@ struct StartPage: View
                                     {
                                         GroupBoxHeadlineGroup(
                                             image: "square.and.arrow.down.on.square",
-                                            title: "You have \(appState.cachedDownloadsFolderSize.formatted(.byteCount(style: .file))) of cached downloads",
-                                            mainText: "These files are leftovers from completed package installations. They're safe to remove."
+                                            title: "start-page.cached-downloads-\(appState.cachedDownloadsFolderSize.formatted(.byteCount(style: .file)))",
+                                            mainText: "start-page.cached-downloads.description"
                                         )
 
                                         Spacer()
@@ -180,7 +180,7 @@ struct StartPage: View
                                         {
                                             appState.isShowingFastCacheDeletionMaintenanceView = true
                                         } label: {
-                                            Text("Delete Cached Downloads…")
+                                            Text("start-page.cached-downloads.action")
                                         }
                                     }
                                 }
@@ -201,7 +201,7 @@ struct StartPage: View
                             print("Would perform maintenance")
                             appState.isShowingMaintenanceSheet.toggle()
                         } label: {
-                            Text("Brew Maintenance…")
+                            Text("start-page.open-maintenance")
                         }
                     }
                 }

--- a/Cork/Views/Taps/Add Tap.swift
+++ b/Cork/Views/Taps/Add Tap.swift
@@ -45,7 +45,7 @@ struct AddTapView: View
             switch progress
             {
             case .ready:
-                SheetWithTitle(title: "Add a tap")
+                SheetWithTitle(title: "add-tap")
                 {
                     TextField("homebrew/core", text: $requestedTap)
                         .onSubmit
@@ -59,13 +59,13 @@ struct AddTapView: View
                                 switch tapInputError
                                 {
                                 case .empty:
-                                    Text("Tap name empty")
+                                    Text("add-tap.typing.error.error")
                                         .font(.headline)
-                                    Text("You didn't put in any tap name")
+                                    Text("add-tap.typing.error.error")
                                 case .missingSlash:
-                                    Text("Tap name needs a slash")
+                                    Text("add-tap.typing.error.slash")
                                         .font(.headline)
-                                    Text("Tap names always have to contain a slash")
+                                    Text("add-tap.typing.error.slash.description")
                                 }
                             }
                             .padding()
@@ -77,7 +77,7 @@ struct AddTapView: View
                         {
                             isShowingSheet.toggle()
                         } label: {
-                            Text("Cancel")
+                            Text("action.cancel")
                         }
                         .keyboardShortcut(.cancelAction)
 
@@ -92,7 +92,7 @@ struct AddTapView: View
                                 progress = .tapping
                             }
                         } label: {
-                            Text("Add")
+                            Text("add-tap.action")
                         }
                         .keyboardShortcut(.defaultAction)
                         .disabled(validateTapName(tapName: requestedTap) != nil)
@@ -102,7 +102,7 @@ struct AddTapView: View
             case .tapping:
                 ProgressView
                 {
-                    Text("Tapping \(requestedTap)")
+                    Text("add-tap.progress-\(requestedTap)")
                 }
                 .onAppear
                 {
@@ -135,17 +135,21 @@ struct AddTapView: View
                 ComplexWithIcon(systemName: "checkmark.seal") {
                     DisappearableSheet(isShowingSheet: $isShowingSheet)
                     {
-                        HeadlineWithSubheadline(headline: "Successfully added \(requestedTap)", subheadline: "There were no errors", alignment: .leading)
-                            .fixedSize(horizontal: true, vertical: true)
-                            .onAppear
-                            {
-                                availableTaps.addedTaps.append(BrewTap(name: requestedTap))
-                                
-                                /// Remove that one element of the array that's empty for some reason
-                                availableTaps.addedTaps.removeAll(where: { $0.name == "" })
-                                
-                                print("Available taps: \(availableTaps.addedTaps)")
-                            }
+                        HeadlineWithSubheadline(
+                            headline: "add-tap.complete-\(requestedTap)",
+                            subheadline: "add-tap.complete.description",
+                            alignment: .leading
+                        )
+                        .fixedSize(horizontal: true, vertical: true)
+                        .onAppear
+                        {
+                            availableTaps.addedTaps.append(BrewTap(name: requestedTap))
+
+                            /// Remove that one element of the array that's empty for some reason
+                            availableTaps.addedTaps.removeAll(where: { $0.name == "" })
+
+                            print("Available taps: \(availableTaps.addedTaps)")
+                        }
                     }
                 }
 
@@ -155,14 +159,14 @@ struct AddTapView: View
                     {
                         switch tappingError {
                         case .repositoryNotFound:
-                                Text("\(requestedTap) doesn't exist")
+                                Text("add-tap.error.repository-not-found-\(requestedTap)")
                                     .font(.headline)
-                                Text("Double-check that you wrote the name right")
+                                Text("add-tap.error.repository-not-found.description")
                         
                         case .other:
-                            Text("An error occured while tapping \(requestedTap)")
+                            Text("add-tap.error.other-\(requestedTap)")
                                 .font(.headline)
-                            Text("Try tapping it again in a few minutes")
+                            Text("add-tap.error.other.description")
                         }
 
                         HStack
@@ -175,7 +179,7 @@ struct AddTapView: View
                             {
                                 progress = .ready
                             } label: {
-                                Text("Try Again")
+                                Text("add-tap.error.action")
                             }
                             .keyboardShortcut(.defaultAction)
                         }

--- a/Cork/Views/Taps/Tap Details/Packages Included in Tap.swift
+++ b/Cork/Views/Taps/Tap Details/Packages Included in Tap.swift
@@ -19,7 +19,7 @@ struct PackagesIncludedInTapList: View
     {
         VStack(spacing: 5)
         {
-            CustomSearchField(search: $searchString, customPromptText: "Included Packages")
+            CustomSearchField(search: $searchString, customPromptText: "tap-details.included-packages.search.prompt")
             ScrollView
             {
                 LazyVStack(spacing: 0)

--- a/Cork/Views/Taps/Tap Details/Tap Details.swift
+++ b/Cork/Views/Taps/Tap Details/Tap Details.swift
@@ -46,7 +46,7 @@ struct TapDetailView: View
                     if isOfficial
                     {
                         Image(systemName: "checkmark.shield")
-                            .help("\(tap.name) an official tap.\nPackages included in it are audited to make sure they are safe.")
+                            .help("tap-details.official-\(tap.name)")
                     }
                 }
             }
@@ -56,7 +56,7 @@ struct TapDetailView: View
                 HStack(alignment: .center) {
                     VStack(alignment: .center) {
                         ProgressView {
-                            Text("Loading tap info...")
+                            Text("tap-details.loading")
                         }
                     }
                 }
@@ -66,7 +66,7 @@ struct TapDetailView: View
             {
                 VStack(alignment: .leading, spacing: 10)
                 {
-                    Text("Info")
+                    Text("tap-details.info")
                         .font(.title2)
 
                     GroupBox
@@ -74,34 +74,34 @@ struct TapDetailView: View
                         Grid(alignment: .leading, horizontalSpacing: 20)
                         {
                             GridRow(alignment: .firstTextBaseline) {
-                                Text("Contents")
+                                Text("tap-details.contents")
                                 
                                 if includedFormulae == nil && includedCasks == nil
                                 {
-                                    Text("None")
+                                    Text("tap-details.contents.none")
                                 }
                                 else if includedFormulae != nil && includedCasks == nil
                                 {
-                                    Text("Only Formulae")
+                                    Text("tap-details.contents.formulae-only")
                                 }
                                 else if includedCasks != nil && includedFormulae == nil
                                 {
-                                    Text("Only Casks")
+                                    Text("tap-details.contents.casks-only")
                                 }
                                 else if includedFormulae?.count ?? 0 > includedCasks?.count ?? 0
                                 {
-                                    Text("Mostly Formulae")
+                                    Text("tap-details.contents.formulae-mostly")
                                 }
                                 else if includedFormulae?.count ?? 0 < includedCasks?.count ?? 0
                                 {
-                                    Text("Mostly Casks")
+                                    Text("tap-details.contents.casks-mostly")
                                 }
                             }
                             
                             Divider()
                             
                             GridRow(alignment: .firstTextBaseline) {
-                                Text("Number of Packages")
+                                Text("tap-details.package-count")
                                 Text(String(numberOfPackages))
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             }
@@ -110,7 +110,7 @@ struct TapDetailView: View
                             
                             GridRow(alignment: .firstTextBaseline)
                             {
-                                Text("Homepage")
+                                Text("tap-details.homepage")
                                 Link(destination: homepage)
                                 {
                                     Text(homepage.absoluteString)
@@ -127,7 +127,7 @@ struct TapDetailView: View
                             {
                                 if let includedFormulae
                                 {
-                                    DisclosureGroup("Formulae Included", isExpanded: $isShowingIncludedFormulae)
+                                    DisclosureGroup("tap-details.included-formulae", isExpanded: $isShowingIncludedFormulae)
                                     {}
                                     .disclosureGroupStyle(NoPadding())
                                     if isShowingIncludedFormulae
@@ -143,7 +143,7 @@ struct TapDetailView: View
                                 
                                 if let includedCasks
                                 {
-                                    DisclosureGroup("Casks Included", isExpanded: $isShowingIncludedCasks)
+                                    DisclosureGroup("tap-details.included-casks", isExpanded: $isShowingIncludedCasks)
                                     {}
                                     .disclosureGroupStyle(NoPadding())
                                     if isShowingIncludedCasks
@@ -169,7 +169,7 @@ struct TapDetailView: View
                                 try await removeTap(name: tap.name, availableTaps: availableTaps, appState: appState)
                             }
                         } label: {
-                            Text("Remove \(tap.name)")
+                            Text("tap-details.remove-\(tap.name)")
                         }
 
                     }

--- a/Cork/Views/Updating/Update Packages View.swift
+++ b/Cork/Views/Updating/Update Packages View.swift
@@ -32,7 +32,7 @@ struct UpdatePackagesView: View
                     switch packageUpdatingStep
                     {
                     case .ready:
-                        Text("Ready")
+                        Text("update-packages.updating.ready")
                             .onAppear
                             {
                                 updateProgressTracker.updateProgress = 0
@@ -40,7 +40,7 @@ struct UpdatePackagesView: View
                             }
 
                     case .checkingForUpdates:
-                        Text("Fetching updates...")
+                        Text("update-packages.updating.checking")
                             .onAppear
                             {
                                 Task(priority: .userInitiated)
@@ -63,7 +63,7 @@ struct UpdatePackagesView: View
                             }
 
                     case .updatingPackages:
-                        Text("Updating packages...")
+                        Text("update-packages.updating.updating")
                             .onAppear
                             {
                                 Task(priority: .userInitiated)
@@ -75,7 +75,7 @@ struct UpdatePackagesView: View
                             }
 
                     case .updatingOutdatedPackageTracker:
-                        Text("Updating package caches...")
+                        Text("update-packages.updating.updating-outdated-package")
                             .onAppear
                             {
                                 Task(priority: .userInitiated) {
@@ -95,7 +95,7 @@ struct UpdatePackagesView: View
                             }
 
                     case .finished:
-                        Text("Done")
+                        Text("update-packages.updating.finished")
                             .onAppear
                             {
                                 packageUpdatingStep = .finished
@@ -110,8 +110,12 @@ struct UpdatePackagesView: View
                 {
                     ComplexWithIcon(systemName: "checkmark.seal")
                     {
-                        HeadlineWithSubheadline(headline: "No updates available", subheadline: "You're all up to date", alignment: .leading)
-                            .fixedSize()
+                        HeadlineWithSubheadline(
+                            headline: "update-packages.no-updates",
+                            subheadline: "update-packages.no-updates.description",
+                            alignment: .leading
+                        )
+                        .fixedSize()
                     }
                 }
 
@@ -120,8 +124,12 @@ struct UpdatePackagesView: View
                 {
                     ComplexWithIcon(systemName: "checkmark.seal")
                     {
-                        HeadlineWithSubheadline(headline: "Sucessfully upgraded packages", subheadline: "There were no errors", alignment: .leading)
-                            .fixedSize()
+                        HeadlineWithSubheadline(
+                            headline: "update-packages.finished",
+                            subheadline: "update-packages.finished.description",
+                            alignment: .leading
+                        )
+                        .fixedSize()
                     }
                 }
 
@@ -130,7 +138,11 @@ struct UpdatePackagesView: View
                 {
                     VStack(alignment: .leading, spacing: 5)
                     {
-                        HeadlineWithSubheadline(headline: "Packages updated with errors", subheadline: "There were some errors during updating.\nCheck below for more information", alignment: .leading)
+                        HeadlineWithSubheadline(
+                            headline: "update-packages.error",
+                            subheadline: "update-packages.error.description",
+                            alignment: .leading
+                        )
                         List
                         {
                             ForEach(updateProgressTracker.errors, id: \.self)

--- a/Cork/en.lproj/Localizable.strings
+++ b/Cork/en.lproj/Localizable.strings
@@ -1,0 +1,160 @@
+// MARK: - Common
+
+"action.close" = "Close";
+"action.cancel" = "Cancel";
+
+// MARK: - Sidebar
+"sidebar.search.prompt" = "Installed Packages";
+"sidebar.section.installed-formulae" = "Installed Formulae";
+"sidebar.section.installed-formulae.contextmenu.uninstall-%@" = "Uninstall %@";
+"sidebar.section.installed-casks" = "Installed Casks";
+"sidebar.section.installed-casks.contextmenu.uninstall-%@" = "Uninstall %@";
+"sidebar.section.added-taps" = "Added Taps";
+"sidebar.section.added-taps.contextmenu.remove-%@" = "Remove %@";
+"sidebar.section.added-taps.remove.title-%@" = "Couldn't remove %@";
+"sidebar.section.added-taps.remove.message" = "Try again in a few minutes, or restart Cork";
+
+// MARK: - Start Page
+"start-page.loading" = "Loading Packages…";
+"start-page.status" = "Homebrew Status";
+"start-page.updates.loading" = "Checking for package updates…";
+"start-page.updates.list" = "Outdated packages";
+"start-page.updates.action" = "Update";
+"start-page.installed-formulae.description" = "Formulae are packages that you use through a terminal";
+"start-page.installed-casks.description" = "Casks are packages that have graphical windows";
+"start-page.added-taps.description" = "Taps provide additional packages";
+"start-page.analytics.disabled" = "Homebrew analytics are disabled";
+"start-page.analytics.disabled.description" = "Homebrew is not collecting any data about how you use it";
+"start-page.analytics.enabled" = "Homebrew analytics are enabled";
+"start-page.analytics.enabled.description" = "Homebrew is collecting various anonymized data, such as which packages you have installed";
+"start-page.cached-downloads-%@" = "You have %@ of cached downloads";
+"start-page.cached-downloads.description" = "These files are leftovers from completed package installations. They're safe to remove.";
+"start-page.cached-downloads.action" = "Delete Cached Downloads…";
+"start-page.open-maintenance" = "Brew Maintenance…";
+
+// MARK: - Add Tap
+"add-tap" = "Add a tap";
+"add-tap.typing.error.empty" = "Tap name empty";
+"add-tap.typing.error.empty.description" = "You didn't put in any tap name";
+"add-tap.typing.error.slash" = "Tap name needs a slash";
+"add-tap.typing.error.slash.description" = "Tap names always have to contain a slash";
+"add-tap.action" = "Add";
+"add-tap.progress-%@" = "Tapping %@";
+"add-tap.complete-%@" = "Successfully added %@";
+"add-tap.complete.description" = "There were no errors";
+"add-tap.error.repository-not-found-%@" = "%@ doesn't exist";
+"add-tap.error.repository-not-found.description" = "Double-check that you wrote the name right";
+"add-tap.error.other-%@" = "An error occured while tapping %@";
+"add-tap.error.other.description" = "Try tapping it again in a few minutes";
+"add-tap.error.action" = "Try Again";
+
+// MARK: - Tap Details
+"tap-details.official-%@" = "%@ is an official tap.\nPackages included in it are audited to make sure they are safe.";
+"tap-details.loading" = "Loading tap info…";
+"tap-details.info" = "Info";
+"tap-details.contents" = "Contents";
+"tap-details.contents.none" = "None";
+"tap-details.contents.formulae-only" = "Only Formulae";
+"tap-details.contents.casks-only" = "Only Casks";
+"tap-details.contents.formulae-mostly" = "Mostly Formulae";
+"tap-details.contents.casks-mostly" = "Mostly Casks";
+"tap-details.package-count" = "Number of Packages";
+"tap-details.homepage" = "Homepage";
+"tap-details.included-formulae" = "Formulae Included";
+"tap-details.included-casks" = "Casks Included";
+"tap-details.remove-%@" = "Remove %@";
+"tap-details.included-packages.search.prompt" = "Included Packages";
+
+// MARK: - Maintenance Steps
+"maintenance.title" = "Maintenance";
+"maintenance.steps.packages" = "Packages:";
+"maintenance.steps.packages.uninstall-orphans" = "Uninstall orphaned packages";
+"maintenance.steps.downloads" = "Downloads:";
+"maintenance.steps.downloads.purge-cache" = "Purge Homebrew cache";
+"maintenance.steps.downloads.delete-cached-downloads" = "Delete cached downloads";
+"maintenance.steps.other" = "Other:";
+"maintenance.steps.other.health-check" = "Perform health check";
+"maintenance.steps.start" = "Start";
+
+// MARK: - Maintenance Progress
+"maintenance.step.initial" = "Firing up…";
+"maintenance.step.removing-orphans" = "Uninstalling orphans…";
+"maintenance.step.purging-cache" = "Purging cache…";
+"maintenance.step.deleting-cached-downloads" = "Deleting cached downloads…";
+"maintenance.step.running-health-check" = "Running health check…";
+"maintenance.finished" = "Maintenance finished";
+"maintenance.results.orphans-none" =  "No orphaned packages found";
+"maintenance.results.orphans-count-%lld" =  "%lld orphaned packages removed";
+"maintenance.results.package-cache" = "Package cache purged";
+"maintenance.results.cached-downloads" = "Cached downloads deleted";
+"maintenance.results.cached-downloads.summary-%@" = "You reclaimed %@";
+"maintenance.results.health-check.problems-none" = "No problems with Homebrew found";
+"maintenance.results.health-check.problems" = "Found some problems with Homebrew";
+"maintenance.results.package-cache.skipped-%@" = "Some caches weren't purged because of %@ not being updated";
+// TODO: Move to plural strings
+"maintenance.results.package-cache.skipped-%@-and-%lld-others" = "Some caches weren't purged because of %@ and %lld others not being updated";
+
+// MARK: - Settings
+"settings.general" = "General";
+"settings.maintenance" = "Maintenance";
+"settings.homebrew" = "Homebrew";
+"settings.install-uninstall" = "Install and Uninstall";
+
+// MARK: - Settings: General
+"settings.general.sort-packages" = "Sort packages by:";
+"settings.general.sort-packages.alphabetically" = "Name";
+"settings.general.sort-packages.install-date" = "Installation Date";
+"settings.general.sort-packages.size" = "Size";
+"settings.general.sort-packages.none" = "Do Not Sort";
+"settings.general.sort-packages.restart" = "􀅴 Restart Cork for this sorting option to take effect";
+"settings.general.dependencies" = "Dependencies:";
+"settings.general.dependencies.toggle" = "Show more info about dependencies";
+"settings.general.package-caveats" = "Package caveats:";
+"settings.general.package-caveats.full" = "Full";
+"settings.general.package-caveats.minified" = "Minified";
+"settings.general.package-caveats.minified.info" = "􀅴 Click on the \"Has caveats\" pill to see the caveats";
+"settings.general.search-results" = "Search results:";
+"settings.general.search-results.toggle" = "Show package descriptions";
+"settings.general.package-details" = "Package details:";
+"settings.general.package-details.toggle" = "Show search field for dependencies";
+
+// MARK: - Settings: Maintenance
+"settings.maintenance.default-steps" = "Set default steps";
+
+// MARK: - Settings: Install/Uninstall
+"settings.install-uninstall.installation" = "Installation:";
+"settings.install-uninstall.installation.toggle" = "Show list of packages currently being installed";
+
+"settings.install-uninstall.uninstallation" = "Uninstallation:";
+"settings.install-uninstall.uninstallation.purge-cache" = "Purge cache after uninstalling packages";
+"settings.install-uninstall.uninstallation.remove-orphans" = "Remove orphans after uninstalling packages";
+
+// MARK: - About
+"about.packages" = "Packages Used";
+"about.packages.1.name" = "DavidFoundation";
+"about.packages.1.purpose" = "My own package that provides some basic convenience features";
+"about.packages.2.name" = "SwiftyJSON";
+"about.packages.2.purpose" = "I hate default JSON parsing in Swift. Why reinvent the wheel when you can just use a library to make it bearable?";
+
+"about.contributor.service.github" = "GitHub";
+"about.contributor.service.mastodon" = "Mastodon";
+
+"about.thanks" = "Special Thanks";
+"about.thanks.1.name" = "Seb Jachec";
+"about.thanks.1.purpose" = "Implemented a function for getting real-time outputs of commands, making more than half of all features in Cork much faster";
+
+"about.contributors" = "Acknowledged Contributors";
+"about.contributors.1.name" = "Rob Napier";
+"about.contributors.1.purpose" = "Gave invaluable help with all sorts of problems, from async Swift to blocking package installations";
+"about.contributors.2.name" = "Łukasz Rutkowski";
+"about.contributors.2.purpose" = "Fixed many async and SwiftUI problems";
+"about.contributors.3.name" = "Jierong Li";
+"about.contributors.3.purpose" = "Fixed package counts on the start page not updating";
+"about.contributors.4.name" = "Oscar Bazaldua";
+"about.contributors.4.purpose" = "Made the first approved pull request; fixed package counts, along with Jierong Li";
+
+"about.contribute" = "Contribute";
+"about.contact" = "Contact Me";
+
+"about.version-%@-%@" = "Version %@ (%@)";
+"about.copyright" = "© 2022 David Bureš and contributors.";

--- a/Cork/en.lproj/Localizable.strings
+++ b/Cork/en.lproj/Localizable.strings
@@ -183,8 +183,6 @@
 "maintenance.results.health-check.problems-none" = "No problems with Homebrew found";
 "maintenance.results.health-check.problems" = "Found some problems with Homebrew";
 "maintenance.results.package-cache.skipped-%@" = "Some caches weren't purged because of %@ not being updated";
-// TODO: Move to plural strings
-"maintenance.results.package-cache.skipped-%@-and-%lld-others" = "Some caches weren't purged because of %@ and %lld others not being updated";
 
 // MARK: - Settings
 "settings.general" = "General";

--- a/Cork/en.lproj/Localizable.strings
+++ b/Cork/en.lproj/Localizable.strings
@@ -1,7 +1,28 @@
 // MARK: - Common
 
+"app-name" = "Cork";
 "action.close" = "Close";
 "action.cancel" = "Cancel";
+
+// MARK: - Navigation
+"navigation.about" = "About Cork";
+"navigation.menu.packages" = "Packages";
+"navigation.menu.packages.install" = "Install Packages…";
+"navigation.menu.packages.add-tap" = "Add a Tap…";
+"navigation.menu.packages.update" = "Update Packages…";
+"navigation.menu.maintenance" = "Maintenance";
+"navigation.menu.maintenance.perform" = "Perform Maintenance…";
+"navigation.menu.maintenance.delete-cached-downloads" = "Delete Cached Downloads";
+
+"navigation.upgrade-packages" = "Upgrade Packages";
+"navigation.upgrade-packages.help" = "Upgrade installed packages";
+"navigation.add-tap" = "Add Tap";
+"navigation.add-tap.help" = "Add a new tap";
+"navigation.install-package" = "Install Package";
+"navigation.install-package.help" = "Add a new package";
+
+"alert.unable-to-uninstall-dependency.title" = "Could Not Uninstall";
+"alert.unable-to-uninstall-dependency.message-%@" = "This package is a dependency of %@";
 
 // MARK: - Sidebar
 "sidebar.search.prompt" = "Installed Packages";
@@ -64,6 +85,77 @@
 "tap-details.included-casks" = "Casks Included";
 "tap-details.remove-%@" = "Remove %@";
 "tap-details.included-packages.search.prompt" = "Included Packages";
+
+// MARK: - Update Packages
+"update-packages.updating.ready" = "Ready";
+"update-packages.updating.checking" = "Fetching updates…";
+"update-packages.updating.updating" = "Updating packages…";
+"update-packages.updating.updating-outdated-package" = "Updating package caches";
+"update-packages.updating.finished" = "Done";
+"update-packages.no-updates" = "No updates available";
+"update-packages.no-updates.description" = "You're all up to date";
+"update-packages.finished" = "Sucessfully upgraded packages";
+"update-packages.finished.description" = "There were no errors";
+"update-packages.error" = "Packages updated with errors";
+"update-packages.error.description" = "There were some errors during updating.\nCheck below for more information";
+
+// MARK: - Install Package
+"add-package.title" = "Install packages";
+"add-package.search.prompt" = "Search for packages…";
+"add-package.search.action" = "Search";
+"add-package.searching-%@" = "Searching for %@…";
+"add-package.search.results.formulae" = "Found Formulae";
+"add-package.search.results.casks" = "Found Casks";
+"add-package.result.already-installed" = "Already Installed";
+"add-package.result.loading-description" = "Loading description…";
+"add-package.install.action" = "Install";
+"add-package.install.ready" = "Building Dependency Graph…";
+"add-package.install.loading-dependencies" = "Loading Dependencies…";
+"add-package.install.fetching-dependencies" = "Fetching Dependencies…";
+"add-package.install.installing-dependencies-%lld-of-%lld" = "Installing Dependency %lld/%lld";
+"add-package.install.installing-package" = "Installing Package…";
+"add-package.install.finished" = "Done!";
+"add-package.install.downloading-cask-%@" = "Downloading %@…";
+"add-package.install.installing-cask-%@" = "Installing %@…";
+"add-package.install.linking-cask-binary" = "Linking Binaries…";
+"add-package.install.moving-cask-%@" = "Moving %@ into the Applications Directory…";
+"add-package.install.finished" = "Done";
+"add-package.finished" = "Packages successfully installed";
+"add-package.finished.description" = "There were no errors";
+
+// MARK: - Package Details
+"package-details.pinned.help-%@" = "%@ is pinned. It will not be updated.";
+"package-details.dependants.dependency-of-%@" = "Dependency of %@";
+"package-details.dependants.loading" = "Loading Dependants…";
+"package-details.outdated" = "Outdated";
+"package-details.caveats.available" = "Has caveats 􀅴";
+"package-details.caveats.help" = "Click to see caveats";
+"package-details.caveats.collapse" = "Collapse";
+"package-details.caveats.expand" = "Expand";
+"package-details.description-none-%@" = "%@ has no description";
+"package-details.contents.loading" = "Loading package info…";
+"package-details.info" = "Info";
+"package-details.type" = "Type";
+"package-details.type.cask" = "Cask";
+"package-details.type.formula" = "Formula";
+"package-details.homepage" = "Homepage";
+"package-details.dependencies" = "Dependencies";
+"package-details.install-date" = "Installed On";
+"package-details.size" = "Size";
+"package-details.size.help" = "Why is the size so small?";
+"package-details.size.help.title" = "Why is the size so small?";
+"package-details.size.help.body-1" = "Casks are not installed into the same installation directory as Formulae. Casks are installed into the Applications directory.";
+"package-details.size.help.body-2" = "Since Cork does not have access to your Applications directory, it cannot get the size of the actual app, only of the metadata associated with the Cask.";
+"package-details.action.pin-version-%@" = "Pin to version %@";
+"package-details.action.unpin-version-%@" = "Unpin from version %@";
+"package-details.action.uninstall-%@" = "Uninstall %@";
+
+"package-details.dependencies.search.prompt" = "Dependencies";
+"package-details.dependencies.results.name" = "Name";
+"package-details.dependencies.results.version" = "Version";
+"package-details.dependencies.results.declaration" = "Declaration Type";
+"package-details.dependencies.results.declaration.direct" = "Direct";
+"package-details.dependencies.results.declaration.indirect" = "Indirect";
 
 // MARK: - Maintenance Steps
 "maintenance.title" = "Maintenance";
@@ -130,6 +222,7 @@
 "settings.install-uninstall.uninstallation.remove-orphans" = "Remove orphans after uninstalling packages";
 
 // MARK: - About
+"about.title" = "About Cork";
 "about.packages" = "Packages Used";
 "about.packages.1.name" = "DavidFoundation";
 "about.packages.1.purpose" = "My own package that provides some basic convenience features";

--- a/Cork/en.lproj/Localizable.stringsdict
+++ b/Cork/en.lproj/Localizable.stringsdict
@@ -18,6 +18,31 @@
 			<string>%lld packages installed</string>
 		</dict>
 	</dict>
+	<key>maintenance.results.package-cache.skipped-%@-and-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@name@%#@count@</string>
+		<key>name</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>other</key>
+			<string></string>
+		</dict>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>one</key>
+			<string>Some caches weren&apos;t purged because of %1$@ and %2$lld other not being updated</string>
+			<key>other</key>
+			<string>Some caches weren&apos;t purged because of %1$@ and %2$lld others not being updated</string>
+		</dict>
+	</dict>
 	<key>start-page.added-taps.count-%lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Cork/en.lproj/Localizable.stringsdict
+++ b/Cork/en.lproj/Localizable.stringsdict
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>start-page.added-taps.count-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>one</key>
+			<string>You have %lld Tap added</string>
+			<key>other</key>
+			<string>You have %lld Taps added</string>
+		</dict>
+	</dict>
+	<key>start-page.installed-casks.count-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>one</key>
+			<string>You have %lld Cask installed</string>
+			<key>other</key>
+			<string>You have %lld Casks installed</string>
+		</dict>
+	</dict>
+	<key>start-page.installed-formulae.count-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>one</key>
+			<string>You have %lld Formula installed</string>
+			<key>other</key>
+			<string>You have %lld Formulae installed</string>
+		</dict>
+	</dict>
+	<key>start-page.updates.count-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>There is %lld outdated package</string>
+			<key>other</key>
+			<string>There are %lld outdated packages</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Cork/en.lproj/Localizable.stringsdict
+++ b/Cork/en.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>navigation.installed-packages.count-%lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>one</key>
+			<string>%lld package installed</string>
+			<key>other</key>
+			<string>%lld packages installed</string>
+		</dict>
+	</dict>
 	<key>start-page.added-taps.count-%lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
**Background**
Extract strings from views into a `Localizable.strings` file and a `Localizable.stringsdict` plist-formatted file for plurals.
This covers: sidebar, settings, about, start, add tap, tap details, and maintenance.

I probably should have split this work up earlier to get your feedback on the general format of localization keys. 😅  Still quite a few more views left to go, which will land in a separate PR if you're happy with this format!

**Changes**
* Views now reference a localisation key like `maintenance.title` rather than than an actual string
* Custom views that took a `String` to display `Text` now take a `LocalizedStringKey` instead
* The only change to copy has been replacing `...` (3 full stops) with `…` (Unicode horizontal ellipsis), everything else is untouched