### PR TITLE
Fix type error in GroupBoxHeadlineGroupWithArbitraryContent

### DIFF
--- a/Cork/Views/Reusables/GroupBox Headline Group.swift
+++ b/Cork/Views/Reusables/GroupBox Headline Group.swift
@@ -41,7 +41,7 @@ struct GroupBoxHeadlineGroup: View
 /// For any artitrary content
 struct GroupBoxHeadlineGroupWithArbitraryContent<Content: View>: View
 {
-    var image: String
+    var image: String?
     @ViewBuilder var content: Content
 
     var body: some View


### PR DESCRIPTION
Fixes compile error due to wrong type of `image` in  `GroupBoxHeadlineGroupWithArbitraryContent`