### PR TITLE
+ Chinese translations for Translator section

### DIFF
--- a/Cork/Views/Settings/Panes/General Pane.swift
+++ b/Cork/Views/Settings/Panes/General Pane.swift
@@ -67,7 +67,7 @@ struct GeneralPane: View
                     Text("settings.general.package-caveats.minified")
                         .tag(PackageCaveatDisplay.mini)
                 } label: {
-                    Text("Package caveats:")
+                    Text("settings.general.package-caveats")
                 }
                 .pickerStyle(.radioGroup)
                 if caveatDisplayOptions == .mini
@@ -93,7 +93,7 @@ struct GeneralPane: View
                         Text("settings.general.package-details.toggle")
                     }
                 } label: {
-                    Text("Package details:")
+                    Text("settings.general.package-details")
                 }
             }
         }

--- a/Cork/zh-Hans.lproj/Localizable.strings
+++ b/Cork/zh-Hans.lproj/Localizable.strings
@@ -244,6 +244,10 @@
 "about.contributors.4.name" = "Oscar Bazaldua";
 "about.contributors.4.purpose" = "发起了第一个通过审核的拉取请求；与 Jierong Li 一起修复了软件包计数功能";
 
+"about.translators" = "翻译";
+"about.translator.1.name" = "Jerry";
+"about.translator.1.purpose" = "为 Cork 提供了中文翻译";
+
 "about.contribute" = "贡献";
 "about.contact" = "联系我";
 


### PR DESCRIPTION
### Changes
- Added Simplified Chinese translations for the translator section :)
- Fixed `Package caveats:` & `Package details:` not localizable

P.S. For anyone who might contribute to the Chinese translation of Cork: I used `软件包` instead of `包` for "package" because that's what they use on homebrew's [official website](https://brew.sh/index_zh-cn). Personally, I prefer the second one, which is more concise, but still, let's respect the official translation.