### PR TITLE
format package count (mainly for thousands separator)

### DIFF
--- a/Cork/Views/Taps/Tap Details/Tap Details.swift
+++ b/Cork/Views/Taps/Tap Details/Tap Details.swift
@@ -102,7 +102,7 @@ struct TapDetailView: View
                             
                             GridRow(alignment: .firstTextBaseline) {
                                 Text("tap-details.package-count")
-                                Text(String(numberOfPackages))
+                                Text(numberOfPackages.formatted())
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             }
                             


### PR DESCRIPTION
...so that the "Number of Packages" says "6,605" instead of "6605".