### PR TITLE
Fix compilation errors on Xcode 14

### DIFF
--- a/Cork/CorkApp.swift
+++ b/Cork/CorkApp.swift
@@ -232,7 +232,7 @@ struct CorkApp: App
     {
         if #available(macOS 14.0, *)
         {
-            NSApp.activate()
+            NSApp.activate(ignoringOtherApps: true)
         }
         else
         {

--- a/Cork/Views/Packages/Package List Item.swift
+++ b/Cork/Views/Packages/Package List Item.swift
@@ -35,7 +35,11 @@ struct PackageListItem: View
                     .foregroundColor(.secondary)
                     .layoutPriority(-Double(2))
             }
-            .animation(.bouncy, value: packageItem.isTagged)
+            #if hasAttribute(bouncy)
+                .animation(.bouncy, value: packageItem.isTagged)
+            #else
+                .animation(.default, value: packageItem.isTagged)
+            #endif
             .transition(.slide)
         }
     }


### PR DESCRIPTION
I'm running macOS 13.5.1 with Xcode 14.3.1 and I had some compilation errors for missing members and arguments.
I've updated the code accordingly.

Since Swift 5.8 attributes can be checked with `hasAttribute` I used this compile conditional
to check for the [Animation.bouncy](https://developer.apple.com/documentation/swiftui/animation/bouncy?changes=latest_minor) attribute, thats available starting from Xcode 15.

Also `NSApp.activate` requires a parameter `ignoringOtherApps` on Xcode 14.
The parameter could be available in Xcode 15 too, so reducing the function `func switchCorkToForeground()` to
`func switchCorkToForeground()
    {
        NSApp.activate(ignoringOtherApps: true)
    }
`
might be sufficient.
However I cannot find any documentation about `.activate()` on versions prior to Xcode 15 for [NSApp](https://developer.apple.com/documentation/appkit/nsapplication)
I have not added this into my commit, but someone who has Xcode 15 could try this approach as it works in Xcode 14.