### PR TITLE
Update localization for untapping fix

### DIFF
--- a/Cork/de.lproj/Localizable.strings
+++ b/Cork/de.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "alert.home-not-set.message" = "Cork cannot access your Homebrew installation\nWe are investigating the cause of this problem, which has appeared in the newest Homebrew or macOS release\nUntil then, Cork will not work. As soon as this problem is fixed, Cork will be updated";
 "alert.notifications-error-while-obtaining-permissions.title" = "There was a problem obtaining notifications permissions";
 "alert.notifications-error-while-obtaining-permissions.message" = "You can keep using Cork without notifications";
+"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@" = "You still have packages installed from %@\nUninstall them and try again";
 
 // MARK: - Sidebar
 "sidebar.search.prompt" = "Installierte Pakete";

--- a/Cork/zh-Hans.lproj/Localizable.strings
+++ b/Cork/zh-Hans.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "alert.home-not-set.message" = "Cork 无法访问 Homebrew\n我们正在调查此问题的原因，该问题可能出现在最新的 Homebrew 或 macOS 版本中\n在此问题解决之前，Cork 将无法使用。Cork 将在问题修复后更新";
 "alert.notifications-error-while-obtaining-permissions.title" = "在获取通知权限时出现问题";
 "alert.notifications-error-while-obtaining-permissions.message" = "你可以在没有通知的情况下继续使用 Cork";
+"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@" = "You still have packages installed from %@\nUninstall them and try again";
 
 // MARK: - Sidebar
 "sidebar.search.prompt" = "已安装软件包";

--- a/Cork/zh-Hans.lproj/Localizable.strings
+++ b/Cork/zh-Hans.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 "alert.home-not-set.message" = "Cork 无法访问 Homebrew\n我们正在调查此问题的原因，该问题可能出现在最新的 Homebrew 或 macOS 版本中\n在此问题解决之前，Cork 将无法使用。Cork 将在问题修复后更新";
 "alert.notifications-error-while-obtaining-permissions.title" = "在获取通知权限时出现问题";
 "alert.notifications-error-while-obtaining-permissions.message" = "你可以在没有通知的情况下继续使用 Cork";
-"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@" = "You still have packages installed from %@\nUninstall them and try again";
+"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@" = "你还有从 %@ 安装的软件包\n请卸载它们并重试";
 
 // MARK: - Sidebar
 "sidebar.search.prompt" = "已安装软件包";

--- a/Cork/zh-Hant.lproj/Localizable.strings
+++ b/Cork/zh-Hant.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "alert.home-not-set.message" = "Cork 無法使用您的 Homebrew 安裝\n我們正在研究這個在最新的 Homebrew 或 macOS 版本上所發現的問題。\nCork 目前無法執行，我們將儘速解決問題並更新。";
 "alert.notifications-error-while-obtaining-permissions.title" = "取得通知許可時發生問題";
 "alert.notifications-error-while-obtaining-permissions.message" = "通知並未啟用，但您可以繼續使用 Cork。";
+"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@" = "You still have packages installed from %@\nUninstall them and try again";
 
 // MARK: - Sidebar
 "sidebar.search.prompt" = "已安裝的套件";


### PR DESCRIPTION
### Changes
- Add localizable strings for German & Chinese
- Update Simplified Chinese localization for `"alert.notification-could-not-remove-tap-due-to-packages-from-it-still-being-installed.message-%@"`