### PR TITLE
Handle targeted concurrency warnings

### DIFF
--- a/Cork.xcodeproj/project.pbxproj
+++ b/Cork.xcodeproj/project.pbxproj
@@ -1550,6 +1550,7 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
 			};
 			name = Debug;
 		};
@@ -1607,6 +1608,7 @@
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = targeted;
 			};
 			name = Release;
 		};

--- a/Cork/AppDelegate.swift
+++ b/Cork/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate
 {
     @AppStorage("showInMenuBar") var showInMenuBar = false
     
-    var appState = AppState()
+    @MainActor let appState = AppState()
     
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool
     {

--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ContentView: View
+struct ContentView: View, Sendable
 {
     @AppStorage("sortPackagesBy") var sortPackagesBy: PackageSortingOptions = .none
     @AppStorage("allowBrewAnalytics") var allowBrewAnalytics: Bool = true

--- a/Cork/Logic/Discoverability/Load up Top Packages.swift
+++ b/Cork/Logic/Discoverability/Load up Top Packages.swift
@@ -46,8 +46,7 @@ func loadUpTopPackages(numberOfDays: Int = 30, isCask: Bool, appState: AppState)
             catch let packageParsingError
             {
                 print("Failed while parsing top packages: \(packageParsingError)")
-                appState.fatalAlertType = .couldNotParseTopPackages
-                appState.isShowingFatalError = true
+                await appState.setCouldNotParseTopPackages()
                 
                 throw packageParsingError
             }

--- a/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
+++ b/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
@@ -71,9 +71,7 @@ func getContentsOfFolder(targetFolder: URL, appState: AppState) async -> [BrewPa
                     else
                     {
                         print("\(item) does not have any versions installed")
-                        appState.corruptedPackage = item
-                        appState.fatalAlertType = .installedPackageHasNoVersions
-                        appState.isShowingFatalError = true
+                        await appState.setCorruptedPackage(item)
                     }
                 }
                 else

--- a/Cork/Logic/Tagging/File Handling/Save Tagged IDs to Disk.swift
+++ b/Cork/Logic/Tagging/File Handling/Save Tagged IDs to Disk.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 func saveTaggedIDsToDisk(appState: AppState) throws
 {
     let namesAsString: String = appState.taggedPackageNames.compactMap { $0 }.joined(separator: ":")

--- a/Cork/Views/Installation/Components/Searching View.swift
+++ b/Cork/Views/Installation/Components/Searching View.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct InstallationSearchingView: View
+struct InstallationSearchingView: View, Sendable
 {
     @Binding var packageRequested: String
 

--- a/Cork/Views/Installation/Reusables/Search Result Row.swift
+++ b/Cork/Views/Installation/Reusables/Search Result Row.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SearchResultRow: View
+struct SearchResultRow: View, Sendable
 {
     @AppStorage("showDescriptionsInSearchResults") var showDescriptionsInSearchResults: Bool = false
     

--- a/Cork/Views/Packages/Package Details/Package Details.swift
+++ b/Cork/Views/Packages/Package Details/Package Details.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftyJSON
 
-struct PackageDetailView: View
+struct PackageDetailView: View, Sendable
 {
     @AppStorage("caveatDisplayOptions") var caveatDisplayOptions: PackageCaveatDisplay = .full
     @AppStorage("allowMoreCompleteUninstallations") var allowMoreCompleteUninstallations: Bool = false

--- a/Cork/Views/Settings/Panes/Notifications Pane.swift
+++ b/Cork/Views/Settings/Panes/Notifications Pane.swift
@@ -37,7 +37,7 @@ struct NotificationsPane: View
                         print("Will re-check notification authorization status")
                         await appState.requestNotificationAuthorization()
                         
-                        switch appState.notificationStatus?.authorizationStatus {
+                        switch appState.notificationAuthStatus {
                             case .notDetermined:
                                 print("Not determined")
                             case .denied:
@@ -48,33 +48,32 @@ struct NotificationsPane: View
                                 print("Provisional")
                             case .ephemeral:
                                 print("Ephemeral")
-                            case nil:
-                                print("Nil")
                             default:
                                 print("TF")
                         }
                         
-                        if appState.notificationStatus?.authorizationStatus == .denied
+                        if appState.notificationAuthStatus == .denied
                         {
                             areNotificationsEnabled = false
                         }
                     }
                     .onChange(of: areNotificationsEnabled, perform: { newValue in
                         Task(priority: .background) {
-                            let notificationsEnabledInSystemSettings: Bool = await appState.requestNotificationAuthorization()
-                            if notificationsEnabledInSystemSettings
+                            await appState.requestNotificationAuthorization()
+                            
+                            if appState.notificationEnabledInSystemSettings == true
                             {
                                 await appState.requestNotificationAuthorization()
-                                if appState.notificationStatus?.authorizationStatus == .denied
+                                if appState.notificationAuthStatus == .denied
                                 {
                                     areNotificationsEnabled = false
                                 }
                             }
                         }
                     })
-                    .disabled(appState.notificationStatus?.authorizationStatus == .denied)
+                    .disabled(appState.notificationAuthStatus == .denied)
                     
-                    if appState.notificationStatus?.authorizationStatus == .denied 
+                    if appState.notificationAuthStatus == .denied
                     {
                         Text("settings.notifications.notifications-disabled-in-settings.tooltip")
                             .font(.caption)

--- a/Cork/Views/Taps/Tap Details/Tap Details.swift
+++ b/Cork/Views/Taps/Tap Details/Tap Details.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct TapDetailView: View
+struct TapDetailView: View, Sendable
 {
     @State var tap: BrewTap
     


### PR DESCRIPTION
Fixes the warnings emitted by setting `SWIFT_STRICT_CONCURRENCY` to `targeted`. I'll add some comments inline to discuss individual changes. 

There is more work to do to get this to `complete` but I think this resolves all the `targeted` warnings to start with. 