### PR TITLE
~ Simplify sidebar search tokens and section views

### DIFF
--- a/Cork.xcodeproj/project.pbxproj
+++ b/Cork.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		63FFE5802A90E7F400F95E54 /* Discoverability Pane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FFE57F2A90E7F400F95E54 /* Discoverability Pane.swift */; };
 		63FFEF4E29CB5D9400D6FFC4 /* Restart App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FFEF4D29CB5D9400D6FFC4 /* Restart App.swift */; };
 		63FFEF5029CB5EEE00D6FFC4 /* Fatal Alert Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FFEF4F29CB5EEE00D6FFC4 /* Fatal Alert Types.swift */; };
+		9606D0AD2AAB8B8E005B7DBA /* Sidebar Package Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9606D0AC2AAB8B8E005B7DBA /* Sidebar Package Row.swift */; };
 		96B86AF529C6561E00844DF4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96B86AF729C6561E00844DF4 /* Localizable.strings */; };
 		96B86AFD29C66E6D00844DF4 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 96B86AFF29C66E6D00844DF4 /* Localizable.stringsdict */; };
 		C45945172A91232900271D99 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = C45945192A91232900271D99 /* index.html */; };
@@ -332,15 +333,13 @@
 		63FFE57F2A90E7F400F95E54 /* Discoverability Pane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discoverability Pane.swift"; sourceTree = "<group>"; };
 		63FFEF4D29CB5D9400D6FFC4 /* Restart App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Restart App.swift"; sourceTree = "<group>"; };
 		63FFEF4F29CB5EEE00D6FFC4 /* Fatal Alert Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fatal Alert Types.swift"; sourceTree = "<group>"; };
+		9606D0AC2AAB8B8E005B7DBA /* Sidebar Package Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sidebar Package Row.swift"; sourceTree = "<group>"; };
 		96B86AF629C6561E00844DF4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		96B86AFE29C66E6D00844DF4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		B0376A5729D26097009C7E6B /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B0376A5829D26097009C7E6B /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		C1AA4F252AA936CA003BCF81 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1AA4F262AA936CA003BCF81 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		C1AA4F272AA936CA003BCF81 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = fr; path = fr.lproj/index.html; sourceTree = "<group>"; };
-		C1AA4F282AA936CA003BCF81 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = fr; path = fr.lproj/topic1.html; sourceTree = "<group>"; };
-		C1AA4F292AA936CA003BCF81 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = fr; path = fr.lproj/topic2.html; sourceTree = "<group>"; };
 		C45945182A91232900271D99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = en; path = en.lproj/index.html; sourceTree = "<group>"; wrapsLines = 0; };
 		C459451B2A91232E00271D99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = en; path = en.lproj/topic1.html; sourceTree = "<group>"; };
 		C459451E2A91233400271D99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = en; path = en.lproj/topic2.html; sourceTree = "<group>"; };
@@ -620,8 +619,9 @@
 		635BE04C2A2B3801004DCBD8 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				635BE04F2A2B3822004DCBD8 /* Formulae Section.swift */,
 				635BE04D2A2B3818004DCBD8 /* Casks Section.swift */,
+				635BE04F2A2B3822004DCBD8 /* Formulae Section.swift */,
+				9606D0AC2AAB8B8E005B7DBA /* Sidebar Package Row.swift */,
 				635BE0512A2B382C004DCBD8 /* Taps Section.swift */,
 			);
 			path = Components;
@@ -1310,6 +1310,7 @@
 				63E716D929DDB918004FD2B4 /* Package And Tap Overview Box.swift in Sources */,
 				63A9778529A7D5800091DF2E /* Synchnorize Installed Packages.swift in Sources */,
 				639A7D832871D08200B50280 /* Install Package.swift in Sources */,
+				9606D0AD2AAB8B8E005B7DBA /* Sidebar Package Row.swift in Sources */,
 				637E006828733C1C005C9890 /* Search for Package by ID.swift in Sources */,
 				637260C529BE42FB00E6E81C /* Get Official Status.swift in Sources */,
 				6342117A29AA52B900E2563B /* Delete Cached Downloads.swift in Sources */,

--- a/Cork/Models/Searching/Package Search Token.swift
+++ b/Cork/Models/Searching/Package Search Token.swift
@@ -8,15 +8,48 @@
 import Foundation
 import SwiftUI
 
-enum TokenSearchType
+enum PackageSearchToken
 {
     case formula, cask, tap, tag, intentionallyInstalledPackage
 }
 
-struct PackageSearchToken: Identifiable
+extension PackageSearchToken: Identifiable
 {
-    var id = UUID()
-    var name: LocalizedStringKey
-    var icon: String
-    var tokenSearchResultType: TokenSearchType
+    var id: Int
+    {
+        hashValue
+    }
+}
+
+extension PackageSearchToken
+{
+    var name: LocalizedStringKey {
+        switch self {
+        case .formula:
+            return "search.token.filter-formulae"
+        case .cask:
+            return "search.token.filter-casks"
+        case .tap:
+            return "search.token.filter-taps"
+        case .tag:
+            return ""
+        case .intentionallyInstalledPackage:
+            return "search.token.filter-manually-installed-packages"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .formula:
+            return "terminal"
+        case .cask:
+            return "macwindow"
+        case .tap:
+            return "spigot"
+        case .tag:
+            return "tag"
+        case .intentionallyInstalledPackage:
+            return "hand.tap"
+        }
+    }
 }

--- a/Cork/Views/Sidebar/Components/Casks Section.swift
+++ b/Cork/Views/Sidebar/Components/Casks Section.swift
@@ -9,100 +9,38 @@ import SwiftUI
 
 struct CasksSection: View {
     
-    @AppStorage("allowMoreCompleteUninstallations") var allowMoreCompleteUninstallations: Bool = false
-    
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var brewData: BrewDataStorage
-    @EnvironmentObject var outdatedPackageTracker: OutdatedPackageTracker
     
-    @Binding var searchText: String
+    let searchText: String
     
     var body: some View {
         Section("sidebar.section.installed-casks")
         {
-            if !appState.isLoadingCasks
-            {
-                ForEach(searchText.isEmpty || searchText.contains("#") ? brewData.installedCasks : brewData.installedCasks.filter { $0.name.contains(searchText) })
-                { cask in
-                    NavigationLink(tag: cask.id, selection: $appState.navigationSelection)
-                    {
-                        PackageDetailView(package: cask)
-                    } label: {
-                        PackageListItem(packageItem: cask)
-                    }
-                    .contextMenu
-                    {
-                        if cask.isTagged
-                        {
-                            Button
-                            {
-                                Task
-                                {
-                                    await untagPackage(package: cask, brewData: brewData, appState: appState)
-                                }
-                            } label: {
-                                Text("sidebar.section.all.contextmenu.untag-\(cask.name)")
-                            }
-                        }
-                        else
-                        {
-                            Button
-                            {
-                                Task
-                                {
-                                    await tagPackage(package: cask, brewData: brewData, appState: appState)
-                                }
-                            } label: {
-                                Text("sidebar.section.all.contextmenu.tag-\(cask.name)")
-                            }
-                        }
-                        
-                        Divider()
-                        
-                        Button
-                        {
-                            Task
-                            {
-                                try await uninstallSelectedPackage(
-                                    package: cask,
-                                    brewData: brewData,
-                                    appState: appState,
-                                    outdatedPackageTracker: outdatedPackageTracker,
-                                    shouldRemoveAllAssociatedFiles: false,
-                                    shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
-                                )
-                            }
-                        } label: {
-                            Text("sidebar.section.installed-casks.contextmenu.uninstall-\(cask.name)")
-                        }
-                        
-                        if allowMoreCompleteUninstallations
-                        {
-                            Button
-                            {
-                                Task
-                                {
-                                    try await uninstallSelectedPackage(
-                                        package: cask,
-                                        brewData: brewData,
-                                        appState: appState,
-                                        outdatedPackageTracker: outdatedPackageTracker,
-                                        shouldRemoveAllAssociatedFiles: true,
-                                        shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
-                                    )
-                                }
-                            } label: {
-                                Text("sidebar.section.installed-formulae.contextmenu.uninstall-deep-\(cask.name)")
-                            }
-                        }
-                    }
-                }
-            }
-            else
+            if appState.isLoadingCasks
             {
                 ProgressView()
             }
+            else
+            {
+                ForEach(displayedCasks)
+                { cask in
+                    SidebarPackageRow(package: cask)
+                }
+            }
         }
         .collapsible(true)
+    }
+
+    private var displayedCasks: [BrewPackage]
+    {
+        if searchText.isEmpty || searchText.contains("#")
+        {
+            return brewData.installedCasks
+        } 
+        else
+        {
+            return brewData.installedCasks.filter { $0.name.contains(searchText) }
+        }
     }
 }

--- a/Cork/Views/Sidebar/Components/Formulae Section.swift
+++ b/Cork/Views/Sidebar/Components/Formulae Section.swift
@@ -23,124 +23,62 @@ struct FormulaeSection: View {
         {
             if !appState.isLoadingFormulae
             {
-                
-                if currentTokens.contains(where: { $0.tokenSearchResultType == .intentionallyInstalledPackage })
-                {
-                    ForEach(searchText.isEmpty ? brewData.installedFormulae.filter({ $0.installedIntentionally == true }) : brewData.installedFormulae.filter({ $0.installedIntentionally == true && $0.name.contains(searchText)}))
-                    { formula in
-                        NavigationLink(tag: formula.id, selection: $appState.navigationSelection)
-                        {
-                            PackageDetailView(package: formula)
-                        } label: {
-                            PackageListItem(packageItem: formula)
-                        }
-                        .contextMenu
-                        {
-                            if !formula.isTagged
-                            {
-                                Button
-                                {
-                                    Task
-                                    {
-                                        await tagPackage(package: formula, brewData: brewData, appState: appState)
-                                    }
-                                } label: {
-                                    Text("sidebar.section.all.contextmenu.tag-\(formula.name)")
-                                }
-                            }
-                            else
-                            {
-                                Button
-                                {
-                                    Task
-                                    {
-                                        await untagPackage(package: formula, brewData: brewData, appState: appState)
-                                    }
-                                } label: {
-                                    Text("sidebar.section.all.contextmenu.untag-\(formula.name)")
-                                }
-                            }
-                            
-                            Divider()
-                            
-                            Button
-                            {
-                                Task
-                                {
-                                    try await uninstallSelectedPackage(
-                                        package: formula,
-                                        brewData: brewData,
-                                        appState: appState,
-                                        outdatedPackageTracker: outdatedPackageTracker,
-                                        shouldRemoveAllAssociatedFiles: false,
-                                        shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
-                                    )
-                                }
-                            } label: {
-                                Text("sidebar.section.installed-formulae.contextmenu.uninstall-\(formula.name)")
-                            }
-                            if allowMoreCompleteUninstallations
-                            {
-                                Button
-                                {
-                                    Task
-                                    {
-                                        try await uninstallSelectedPackage(
-                                            package: formula,
-                                            brewData: brewData,
-                                            appState: appState,
-                                            outdatedPackageTracker: outdatedPackageTracker,
-                                            shouldRemoveAllAssociatedFiles: true,
-                                            shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
-                                        )
-                                    }
-                                } label: {
-                                    Text("sidebar.section.installed-formulae.contextmenu.uninstall-deep-\(formula.name)")
-                                }
-                            }
-                            
-                        }
+                ForEach(displayedFormulae)
+                { formula in
+                    NavigationLink(tag: formula.id, selection: $appState.navigationSelection)
+                    {
+                        PackageDetailView(package: formula)
+                    } label: {
+                        PackageListItem(packageItem: formula)
                     }
-                }
-                else
-                {
-                    ForEach(searchText.isEmpty || searchText.contains("#") ? brewData.installedFormulae : brewData.installedFormulae.filter { $0.name.contains(searchText) })
-                    { formula in
-                        NavigationLink(tag: formula.id, selection: $appState.navigationSelection)
+                    .contextMenu
+                    {
+                        if !formula.isTagged
                         {
-                            PackageDetailView(package: formula)
-                        } label: {
-                            PackageListItem(packageItem: formula)
+                            Button
+                            {
+                                Task
+                                {
+                                    await tagPackage(package: formula, brewData: brewData, appState: appState)
+                                }
+                            } label: {
+                                Text("sidebar.section.all.contextmenu.tag-\(formula.name)")
+                            }
                         }
-                        .contextMenu
+                        else
                         {
-                            if !formula.isTagged
+                            Button
                             {
-                                Button
+                                Task
                                 {
-                                    Task
-                                    {
-                                        await tagPackage(package: formula, brewData: brewData, appState: appState)
-                                    }
-                                } label: {
-                                    Text("sidebar.section.all.contextmenu.tag-\(formula.name)")
+                                    await untagPackage(package: formula, brewData: brewData, appState: appState)
                                 }
+                            } label: {
+                                Text("sidebar.section.all.contextmenu.untag-\(formula.name)")
                             }
-                            else
+                        }
+
+                        Divider()
+
+                        Button
+                        {
+                            Task
                             {
-                                Button
-                                {
-                                    Task
-                                    {
-                                        await untagPackage(package: formula, brewData: brewData, appState: appState)
-                                    }
-                                } label: {
-                                    Text("sidebar.section.all.contextmenu.untag-\(formula.name)")
-                                }
+                                try await uninstallSelectedPackage(
+                                    package: formula,
+                                    brewData: brewData,
+                                    appState: appState,
+                                    outdatedPackageTracker: outdatedPackageTracker,
+                                    shouldRemoveAllAssociatedFiles: false,
+                                    shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
+                                )
                             }
-                            
-                            Divider()
-                            
+                        } label: {
+                            Text("sidebar.section.installed-formulae.contextmenu.uninstall-\(formula.name)")
+                        }
+
+                        if allowMoreCompleteUninstallations
+                        {
                             Button
                             {
                                 Task
@@ -150,34 +88,15 @@ struct FormulaeSection: View {
                                         brewData: brewData,
                                         appState: appState,
                                         outdatedPackageTracker: outdatedPackageTracker,
-                                        shouldRemoveAllAssociatedFiles: false,
+                                        shouldRemoveAllAssociatedFiles: true,
                                         shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
                                     )
                                 }
                             } label: {
-                                Text("sidebar.section.installed-formulae.contextmenu.uninstall-\(formula.name)")
-                            }
-                            
-                            if allowMoreCompleteUninstallations
-                            {
-                                Button
-                                {
-                                    Task
-                                    {
-                                        try await uninstallSelectedPackage(
-                                            package: formula,
-                                            brewData: brewData,
-                                            appState: appState,
-                                            outdatedPackageTracker: outdatedPackageTracker,
-                                            shouldRemoveAllAssociatedFiles: true,
-                                            shouldApplyUninstallSpinnerToRelevantItemInSidebar: true
-                                        )
-                                    }
-                                } label: {
-                                    Text("sidebar.section.installed-formulae.contextmenu.uninstall-deep-\(formula.name)")
-                                }
+                                Text("sidebar.section.installed-formulae.contextmenu.uninstall-deep-\(formula.name)")
                             }
                         }
+
                     }
                 }
             }
@@ -187,5 +106,39 @@ struct FormulaeSection: View {
             }
         }
         .collapsible(true)
+    }
+
+    private var displayedFormulae: [BrewPackage]
+    {
+        guard !appState.isLoadingFormulae else
+        {
+            return []
+        }
+
+        let filter: (BrewPackage) -> Bool
+
+        if currentTokens.contains(.intentionallyInstalledPackage)
+        {
+            if searchText.isEmpty
+            {
+                filter = \.installedIntentionally
+            } else
+            {
+                filter = { $0.installedIntentionally && $0.name.contains(searchText)  }
+            }
+        } 
+        else
+        {
+            if searchText.isEmpty || searchText.contains("#")
+            {
+                filter = { _ in true }
+            } 
+            else
+            {
+                filter = { $0.name.contains(searchText) }
+            }
+        }
+
+        return brewData.installedFormulae.filter(filter)
     }
 }

--- a/Cork/Views/Sidebar/Components/Taps Section.swift
+++ b/Cork/Views/Sidebar/Components/Taps Section.swift
@@ -12,7 +12,7 @@ struct TapsSection: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var availableTaps: AvailableTaps
     
-    @Binding var searchText: String
+    let searchText: String
     
     var body: some View {
         Section("sidebar.section.added-taps")
@@ -21,7 +21,6 @@ struct TapsSection: View {
             {
                 ForEach(searchText.isEmpty || searchText.contains("#") ? availableTaps.addedTaps : availableTaps.addedTaps.filter { $0.name.contains(searchText) })
                 { tap in
-                    
                     NavigationLink(tag: tap.id, selection: $appState.navigationSelection)
                     {
                         TapDetailView(tap: tap)

--- a/Cork/Views/Sidebar/Sidebar View.swift
+++ b/Cork/Views/Sidebar/Sidebar View.swift
@@ -16,10 +16,7 @@ struct SidebarView: View
     @State private var isShowingSearchField: Bool = false
     @State private var searchText: String = ""
     @State private var availableTokens: [PackageSearchToken] = [
-        PackageSearchToken(name: "search.token.filter-formulae", icon: "terminal", tokenSearchResultType: .formula),
-        PackageSearchToken(name: "search.token.filter-casks", icon: "macwindow", tokenSearchResultType: .cask),
-        PackageSearchToken(name: "search.token.filter-taps", icon: "spigot", tokenSearchResultType: .tap),
-        PackageSearchToken(name: "search.token.filter-manually-installed-packages", icon: "hand.tap", tokenSearchResultType: .intentionallyInstalledPackage)
+        .formula, .cask, .tap, .intentionallyInstalledPackage
     ]
     @State private var currentTokens: [PackageSearchToken] = .init()
     
@@ -39,17 +36,17 @@ struct SidebarView: View
     {
         List
         {
-            if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .formula }) || currentTokens.contains(where: { $0.tokenSearchResultType == .intentionallyInstalledPackage })
+            if currentTokens.isEmpty || currentTokens.contains(.formula) || currentTokens.contains(.intentionallyInstalledPackage)
             {
                 FormulaeSection(currentTokens: $currentTokens, searchText: $searchText)
             }
             
-            if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .cask }) || currentTokens.contains(where: { $0.tokenSearchResultType == .intentionallyInstalledPackage })
+            if currentTokens.isEmpty || currentTokens.contains(.cask) || currentTokens.contains(.intentionallyInstalledPackage)
             {
                 CasksSection(searchText: $searchText)
             }
             
-            if currentTokens.isEmpty || currentTokens.contains(where: { $0.tokenSearchResultType == .tap })
+            if currentTokens.isEmpty || currentTokens.contains(.tap)
             {
                 TapsSection(searchText: $searchText)
             }

--- a/Cork/Views/Sidebar/Sidebar View.swift
+++ b/Cork/Views/Sidebar/Sidebar View.swift
@@ -38,17 +38,17 @@ struct SidebarView: View
         {
             if currentTokens.isEmpty || currentTokens.contains(.formula) || currentTokens.contains(.intentionallyInstalledPackage)
             {
-                FormulaeSection(currentTokens: $currentTokens, searchText: $searchText)
+                FormulaeSection(currentTokens: currentTokens, searchText: searchText)
             }
             
             if currentTokens.isEmpty || currentTokens.contains(.cask) || currentTokens.contains(.intentionallyInstalledPackage)
             {
-                CasksSection(searchText: $searchText)
+                CasksSection(searchText: searchText)
             }
             
             if currentTokens.isEmpty || currentTokens.contains(.tap)
             {
-                TapsSection(searchText: $searchText)
+                TapsSection(searchText: searchText)
             }
         }
         .listStyle(.sidebar)


### PR DESCRIPTION
Main changes:
* Merge `TokenSearchType` and `PackageSearchToken` into an enum with properties for name and icon, which slightly simplifies some of the array logic in the sidebar view
* Extract a reusable view for sidebar package row views – this is now used in both the formulae and casks sections

I think there's room for further refactoring and simplification, but this felt like an incremental step in the right direction.