### PR TITLE
Migrate to new navigation APIs

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -29,15 +29,15 @@ struct ContentView: View
     @EnvironmentObject var updateProgressTracker: UpdateProgressTracker
 
     @State private var multiSelection = Set<UUID>()
+    @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
 
     var body: some View
     {
         VStack
         {
-            NavigationView
-            {
+            NavigationSplitView(columnVisibility: $columnVisibility) {
                 SidebarView()
-
+            } detail: {
                 StartPage()
                     .frame(minWidth: 600, minHeight: 500)
             }

--- a/Cork/Views/Sidebar/Components/Sidebar Package Row.swift
+++ b/Cork/Views/Sidebar/Components/Sidebar Package Row.swift
@@ -18,9 +18,9 @@ struct SidebarPackageRow: View {
     @EnvironmentObject var outdatedPackageTracker: OutdatedPackageTracker
 
     var body: some View {
-        NavigationLink(tag: package.id, selection: $appState.navigationSelection)
-        {
+        NavigationLink {
             PackageDetailView(package: package)
+                .id(package.id)
         } label: {
             PackageListItem(packageItem: package)
         }

--- a/Cork/Views/Sidebar/Components/Taps Section.swift
+++ b/Cork/Views/Sidebar/Components/Taps Section.swift
@@ -21,16 +21,16 @@ struct TapsSection: View {
             {
                 ForEach(searchText.isEmpty || searchText.contains("#") ? availableTaps.addedTaps : availableTaps.addedTaps.filter { $0.name.contains(searchText) })
                 { tap in
-                    NavigationLink(tag: tap.id, selection: $appState.navigationSelection)
-                    {
+                    NavigationLink {
                         TapDetailView(tap: tap)
+                            .id(tap.id)
                     } label: {
                         Text(tap.name)
 
                         if tap.isBeingModified
                         {
                             Spacer()
-                            
+
                             ProgressView()
                                 .frame(height: 5)
                                 .scaleEffect(0.5)

--- a/Cork/Views/Sidebar/Sidebar View.swift
+++ b/Cork/Views/Sidebar/Sidebar View.swift
@@ -34,7 +34,8 @@ struct SidebarView: View
     
     var body: some View
     {
-        List
+        /// Navigation selection enables "Home" button behaviour. [2023.09]
+        List(selection: $appState.navigationSelection)
         {
             if currentTokens.isEmpty || currentTokens.contains(.formula) || currentTokens.contains(.intentionallyInstalledPackage)
             {


### PR DESCRIPTION
What's Changed:
- Replace `NavigationView` with `NavigationSplitView`.
- Replace deprecated `NavigationLink` calls.

Additional Context:
- NavigationLink destination views now have explicit identities assigned to them. Without it, split view fails to recognize that a new sidebar row has been selected.
- Sidebar list now gets a reference to `appState.navigationSelection`. This is needed to keep existing Home button behaviour (without it, it doesn't work at all).

Notes:
I didn't add anything to toggle the sidebar button visibility for two reasons:
- Requires macOS 14.0.
- When I first ran this app, the sidebar view was hidden for some reason (and there was no sidebar icon), and I got *very* confused.