### PR TITLE
^ (de)select all doesn't work in outdated list

### DIFF
--- a/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
+++ b/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
@@ -86,7 +86,7 @@ struct OutdatedPackageListBox: View
                                                     var copyOutdatedPackage = modifiedElement
                                                     if copyOutdatedPackage.id == modifiedElement.id
                                                     {
-                                                        copyOutdatedPackage.isMarkedForUpdating = true
+                                                        copyOutdatedPackage.isMarkedForUpdating = false
                                                     }
                                                     return copyOutdatedPackage
                                                 }))
@@ -102,7 +102,7 @@ struct OutdatedPackageListBox: View
                                                     var copyOutdatedPackage = modifiedElement
                                                     if copyOutdatedPackage.id == modifiedElement.id
                                                     {
-                                                        copyOutdatedPackage.isMarkedForUpdating = false
+                                                        copyOutdatedPackage.isMarkedForUpdating = true
                                                     }
                                                     return copyOutdatedPackage
                                                 }))


### PR DESCRIPTION
I was trying out Cork for the first time when I noticed that the "deselect all" and "select all" buttons in the "Outdated packages" list weren't working. The fix was straightforward.