### PR TITLE
^ Detection of analytics being enabled

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -191,7 +191,7 @@ struct ContentView: View, Sendable
 
             async let analyticsQueryCommand = await shell(AppConstants.brewExecutablePath.absoluteString, ["analytics"])
 
-            if await analyticsQueryCommand.standardOutput.contains("Analytics are enabled")
+            if await analyticsQueryCommand.standardOutput.localizedCaseInsensitiveContains("Analytics are enabled")
             {
                 allowBrewAnalytics = true
                 print("Analytics are ENABLED")


### PR DESCRIPTION
Seems like in one of Brew updates they changed the output format of `brew analytics`. It now prints:
```
InfluxDB analytics are enabled.
Google Analytics were destroyed.
```
However, Cork was looking for a `"Analytics are enabled"` substring (notice the capital A).  
This caused Cork to incorrectly assume that analytics are disabled, despite being the opposite.

I fixed it by using a case-insensitive version of `contains` to keep compatibility with old Brew versions which may have the old `brew analytics` output format.