### PR TITLE
Highlight install ToolbarItem Button

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -95,6 +95,8 @@ struct ContentView: View, Sendable
                         }
                     }
                     .help("navigation.install-package.help")
+                    .background(Color.accentColor)
+                    .cornerRadius(6.0)
                 }
 
                 #warning("TODO: Implement this button")


### PR DESCRIPTION
Hi,

although cork is absolutely gorgeous, I think cork needs some color.
I'm not familiar with the SwiftUI/Apple Design Guidelines, but wouldn't it be nice?
Cork doesn't necessarily have to be colorful, I like it the way it is, but I think a few buttons and menus should be highlighted using colors. Or use system accent colors to make it more personal.

When I want to install packages, I press that little 'plus icon' and thought it might make sense to highlight this a little more. Because this is, among other things, a core task for Cork.

Just an idea, which could certainly be refined far more:
![proposal](https://github.com/buresdv/Cork/assets/10577573/7836a35d-8048-4d6d-aaa1-527ea86e51b2)

I do not intend to break the simple and sleek design of Cork though.
What do you guys think?