### PR TITLE
^ Single outdated packages toggle doesn't work in outdated list

### DIFF
--- a/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
+++ b/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
@@ -73,7 +73,7 @@ struct OutdatedPackageListBox: View
                                                 }, set: { toggleState in
                                                     outdatedPackageTracker.outdatedPackages = Set(outdatedPackageTracker.outdatedPackages.map({ modifiedElement in
                                                         var copyOutdatedPackage = modifiedElement
-                                                        if copyOutdatedPackage.id == modifiedElement.id
+                                                        if copyOutdatedPackage.id == outdatedPackage.id
                                                         {
                                                             copyOutdatedPackage.isMarkedForUpdating = toggleState
                                                         }


### PR DESCRIPTION
I'm trying out Cork, and I noticed when toogle outdated list package it will select or de-select wall list.