### PR TITLE
Fix `OutlinedPillText` radius to prevent text overflow

### DIFF
--- a/Cork/Views/Shared/PillText.swift
+++ b/Cork/Views/Shared/PillText.swift
@@ -7,23 +7,6 @@
 
 import SwiftUI
 
-struct PillText: View
-{
-    @State var text: String
-    @State var color: NSColor = .tertiaryLabelColor
-    @State var font: Font = .caption
-    
-    var body: some View
-    {
-        Text(text)
-            .font(font)
-            .padding(.horizontal, 4)
-            .background(Color(color))
-            .foregroundColor(.white)
-            .clipShape(Capsule())
-    }
-}
-
 struct PillTextWithLocalizableText: View
 {
     @State var localizedText: LocalizedStringKey

--- a/Cork/Views/Shared/PillText.swift
+++ b/Cork/Views/Shared/PillText.swift
@@ -35,7 +35,7 @@ struct OutlinedPillText: View
             .font(.caption2)
             .padding(.horizontal, 4)
             .foregroundColor(color)
-            .overlay(Capsule().stroke(color, lineWidth: 1))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(color, lineWidth: 1))
     }
 }
 
@@ -50,6 +50,6 @@ struct OutlinedPill<Content: View>: View
             .font(.caption2)
             .padding(.horizontal, 4)
             .foregroundColor(color)
-            .overlay(Capsule().stroke(color, lineWidth: 1))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(color, lineWidth: 1))
     }
 }


### PR DESCRIPTION
According to [Apple Developer Document](https://developer.apple.com/documentation/swiftui/capsule#overview):

> A capsule shape is equivalent to a rounded rectangle where the corner radius is chosen as half the length of the rectangle’s smallest edge.

- `Capsule`: <https://developer.apple.com/documentation/swiftui/capsule>
- `RoundedRectangle`: <https://developer.apple.com/documentation/swiftui/roundedrectangle>

| Before | After |
| ------ | ----- |
| ![截屏2024-01-11 20.09.54](https://github.com/buresdv/Cork/assets/29367025/ea2f962e-73d8-4538-bfd4-fb871828ca26) | ![截屏2024-01-11 20.08.22](https://github.com/buresdv/Cork/assets/29367025/b876e9a1-9db7-4b12-b1ae-aceac3d947f1) |
| ![截屏2024-01-11 20.10.00](https://github.com/buresdv/Cork/assets/29367025/04a63844-c960-416e-9b04-c1244727c0da) | ![截屏2024-01-11 20.09.21.png](https://github.com/buresdv/Cork/assets/29367025/3a5ad941-24b8-4777-9293-f033eaee2621) |

