### PR TITLE
[ISSUE-137] Add search for package version support

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -5119,6 +5119,30 @@
         }
       }
     },
+    "add-package.search.prompt.version" : {
+      "comment" : "Specify a version for user's search prompt",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "With version..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本号…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本號⋯"
+          }
+        }
+      }
+    },
     "add-package.search.results.casks" : {
       "localizations" : {
         "cs" : {
@@ -9443,6 +9467,9 @@
           }
         }
       }
+    },
+    "Key" : {
+      "extractionState" : "manual"
     },
     "Loading info..." : {
       "localizations" : {

--- a/Cork/Logic/Search/Search for Package.swift
+++ b/Cork/Logic/Search/Search for Package.swift
@@ -7,19 +7,23 @@
 
 import Foundation
 
-func searchForPackage(packageName: String, packageType: PackageType) async throws -> [String]
+func searchForPackage(_ packageName: String, of packageType: PackageType, withVersion version: String?) async throws -> [String]
 {
     var finalPackageArray: [String]
+    
+    var searchArg = getSearchArg(from: packageName, with: version)
 
     switch packageType
     {
     case .formula:
-        let foundFormulae = await shell(AppConstants.brewExecutablePath, ["search", "--formulae", packageName])
+        print("Search arg: \(searchArg)")
+        let foundFormulae = await shell(AppConstants.brewExecutablePath, ["search", "--formulae", searchArg])
 
         finalPackageArray = foundFormulae.standardOutput.components(separatedBy: "\n")
 
     case .cask:
-        let foundCasks = await shell(AppConstants.brewExecutablePath, ["search", "--casks", packageName])
+        print("Search arg: \(searchArg)")
+        let foundCasks = await shell(AppConstants.brewExecutablePath, ["search", "--casks", searchArg])
 
         finalPackageArray = foundCasks.standardOutput.components(separatedBy: "\n")
     }
@@ -29,4 +33,25 @@ func searchForPackage(packageName: String, packageType: PackageType) async throw
     print("Search found these: \(finalPackageArray)")
     
     return finalPackageArray
+}
+
+private func getSearchArg(from packageName: String, with version: String?) -> String
+{
+    var searchPackageName = packageName
+
+    if let version = version, !version.isEmpty
+    {
+        // won't do version regex checking here
+
+        let packageNameComponents = packageName.components(separatedBy: "@")
+        
+        if (packageNameComponents.count > 0)
+        {
+            searchPackageName = packageNameComponents[0]  // truncate user's `@` input
+        }
+
+        return "\(searchPackageName)@\(version)"
+    }
+
+    return searchPackageName
 }

--- a/Cork/Views/Installation/Install Package.swift
+++ b/Cork/Views/Installation/Install Package.swift
@@ -12,6 +12,7 @@ struct AddFormulaView: View
     @Binding var isShowingSheet: Bool
 
     @State private var packageRequested: String = ""
+    @State private var versionRequested: String = ""
 
     @EnvironmentObject var brewData: BrewDataStorage
     @EnvironmentObject var appState: AppState
@@ -43,6 +44,7 @@ struct AddFormulaView: View
                         searchResultTracker: searchResultTracker,
                         isShowingSheet: $isShowingSheet,
                         packageRequested: $packageRequested,
+                        versionRequested: $versionRequested,
                         foundPackageSelection: $foundPackageSelection,
                         installationProgressTracker: installationProgressTracker,
                         packageInstallationProcessStep: $packageInstallationProcessStep
@@ -52,6 +54,7 @@ struct AddFormulaView: View
             case .searching:
                 InstallationSearchingView(
                     packageRequested: $packageRequested,
+                    versionRequested: $versionRequested,
                     searchResultTracker: searchResultTracker,
                     packageInstallationProcessStep: $packageInstallationProcessStep
                 )

--- a/Cork/Views/Installation/Sub-Views/Initial.swift
+++ b/Cork/Views/Installation/Sub-Views/Initial.swift
@@ -27,6 +27,7 @@ struct InstallationInitialView: View
 
     @Binding var isShowingSheet: Bool
     @Binding var packageRequested: String
+    @Binding var versionRequested: String
 
     @Binding var foundPackageSelection: Set<UUID>
 
@@ -69,6 +70,8 @@ struct InstallationInitialView: View
             {
                 isSearchFieldFocused.toggle()
             }
+            
+            TextField("add-package.search.prompt.version", text: $versionRequested)
 
             HStack
             {

--- a/Cork/Views/Installation/Sub-Views/Searching.swift
+++ b/Cork/Views/Installation/Sub-Views/Searching.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct InstallationSearchingView: View, Sendable
 {
     @Binding var packageRequested: String
+    @Binding var versionRequested: String
 
     @ObservedObject var searchResultTracker: SearchResultTracker
 
@@ -25,8 +26,8 @@ struct InstallationSearchingView: View, Sendable
                     searchResultTracker.foundFormulae = []
                     searchResultTracker.foundCasks = []
 
-                    async let foundFormulae = try searchForPackage(packageName: packageRequested, packageType: .formula)
-                    async let foundCasks = try searchForPackage(packageName: packageRequested, packageType: .cask)
+                    async let foundFormulae = try searchForPackage(packageRequested, of: .formula, withVersion: versionRequested)
+                    async let foundCasks = try searchForPackage(packageRequested, of: .cask, withVersion: versionRequested)
 
                     for formula in try await foundFormulae
                     {


### PR DESCRIPTION
Hi David, I was using this app for a while and found it very good to maintain my local formulae/casks of Homebrew. While the listing function is great, the app would be more enhanced if we could add version specificity when users are searching for packages.

I found you already issued a feature request at [here](https://github.com/buresdv/Cork/issues/137), so in this PR I am adding this function.

The flow is simple, but some discussions can be made regarding which search method would be best for user experience. In the issue you mentioned two ways of specifying a package version, but what we can do as well is using `grep` like below:

```sh
brew formulae | grep@postgresql@14
```

The search goes to local database, so the result could be faster rendered and more accurate.

<img width="375" alt="image" src="https://github.com/buresdv/Cork/assets/33169107/11a92d44-5230-42bf-a0c7-c7307da6c57d">

Being said, I think `brew search` is also appreciated because it has more tolerance to accepting user's prompt. What do you think? Looking forward to your reply.