### PR TITLE
Add confirmation dialog when uninstalling/purging a package

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -15732,6 +15732,26 @@
         }
       }
     },
+    "package-details.action.uninstall-deep.message-%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to purge %@ ?"
+          }
+        }
+      }
+    },
+    "package-details.action.uninstall.message-%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to uninstall %@ ?"
+          }
+        }
+      }
+    },
     "package-details.action.unpin-version-%@" : {
       "localizations" : {
         "cs" : {


### PR DESCRIPTION
While using the application, I accidentally uninstalled a package. I would expect a confirmation before running the destructive action.

This PR adds a confirmation dialog when uninstalling/purging a package, avoiding accidental clicks.

![Screenshot 2024-04-02 at 10 28 46](https://github.com/buresdv/Cork/assets/439551/d69db934-c4c2-43d9-a977-3d4a84bc454f)
![Screenshot 2024-04-02 at 10 29 00](https://github.com/buresdv/Cork/assets/439551/1853ec0c-a20f-4a64-a851-ddc63ce6bf03)
