### PR TITLE
Force dump to overwrite an existing Brewfile

### DIFF
--- a/Cork/Logic/Brewfile/Export Brewfile.swift
+++ b/Cork/Logic/Brewfile/Export Brewfile.swift
@@ -18,15 +18,16 @@ func exportBrewfile(appState: AppState) async throws -> String
 {
     appState.isShowingBrewfileExportProgress = true
     
-    defer {
+    defer
+    {
         appState.isShowingBrewfileExportProgress = false
     }
     
-    let brewfileParentLocation: URL = URL.temporaryDirectory
+    let brewfileParentLocation = URL.temporaryDirectory
     
     let pathRawOutput = await shell(URL(string: "/bin/pwd")!, ["-L"])
     
-    async let brewfileDumpingResult: TerminalOutput = await shell(AppConstants.brewExecutablePath, ["bundle", "dump"], workingDirectory: brewfileParentLocation)
+    async let brewfileDumpingResult: TerminalOutput = await shell(AppConstants.brewExecutablePath, ["bundle", "-f", "dump"], workingDirectory: brewfileParentLocation)
 
     /// Throw an error if the working directory could not be determined
     if !pathRawOutput.standardError.isEmpty
@@ -35,7 +36,8 @@ func exportBrewfile(appState: AppState) async throws -> String
     }
 
     /// Throw an error if the working directory is so fucked up it's unusable
-    guard let workingDirectory: URL = URL(string: pathRawOutput.standardOutput.replacingOccurrences(of: "\n", with: "")) else
+    guard let workingDirectory = URL(string: pathRawOutput.standardOutput.replacingOccurrences(of: "\n", with: ""))
+    else
     {
         throw BrewfileDumpingError.couldNotDetermineWorkingDirectory
     }


### PR DESCRIPTION
When trying to export a Homebrew backup, I got the following error message:
```
Couldn't write Homebrew backup
Try again, or restart Cork
```

Somehow, an existing `Brewfile` was already present in the temporary directory, leading Brew to throw an error.
This PR adds a flag to force the dump to overwrite an existing Brewfile:
`brew bundle -f dump`.