### PR TITLE
Add package details popover to the outdated packages list

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -11494,7 +11494,7 @@
       "localizations" : {
         "cs" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Homebrew poskytnul nesprávnou odezvu"
           }
         },
@@ -12327,7 +12327,7 @@
       "localizations" : {
         "cs" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Homebrew poskytnul nesprávnou odezvu"
           }
         },
@@ -13475,6 +13475,12 @@
     },
     "debug.action.licensing" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Licence"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13491,6 +13497,12 @@
     },
     "debug.action.reset-license-state" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Resetovat stav licence"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13507,6 +13519,12 @@
     },
     "debug.navigation" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13523,6 +13541,12 @@
     },
     "error.brewfile.export.could-not-determine-working-directory" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při zjišťování složky pro export souboru Brewfile se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13551,6 +13575,12 @@
     },
     "error.brewfile.export.could-not-dump-with-error.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při exportu souboru Brewfile se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13579,6 +13609,12 @@
     },
     "error.brewfile.export.could-not-read-temporary-brewfile" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při čtení obsahu dočasného souboru Brewfile se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13664,6 +13700,12 @@
     },
     "error.brewfile.importing.could-not-import.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při importování souboru Brewfile se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13726,6 +13768,12 @@
     },
     "error.data-downloading.invalid-response.undetermined-response-code" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Homebrew odpověděl s neplatným kódem, a tento kód nebylo možné přečíst"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13986,6 +14034,12 @@
     },
     "error.json-parsing.could-not-decode.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při dekódování JSON se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14008,6 +14062,12 @@
     },
     "error.licensing.auth-complex-not-encoded" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorizační komplex pro účely načtení licence se nepovedlo zakódovat"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14030,6 +14090,12 @@
     },
     "error.licensing.not-connected-to-internet" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nejste připojeni k internetu. Licenci nebylo možné ověřit"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14052,6 +14118,12 @@
     },
     "error.licensing.other-error.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při zjišťování stavu licence se vyskytla neimpleentovaná chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14130,6 +14202,12 @@
     },
     "error.maintenance.health-check.standard-error-not-empty" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funkce vrátila chyby"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14197,6 +14275,12 @@
     },
     "error.maintenance.orphan-removal.could-not-uninstall-orphans.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při odinstalování osiřelých balíčku se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14219,6 +14303,12 @@
     },
     "error.maintenance.orphan-uninstallation.unexpected-terminal-output" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funkce pro odinstalaci osiřelých balíčků poskytla nečekanou odezvu"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14411,6 +14501,12 @@
     },
     "error.package-loading.%@-does-not-have-any-versions-installed" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balíček %@ nemá nainstalované žádné verze"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14540,6 +14636,12 @@
     },
     "error.package-loading.could-not-load-packages" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při načítání balíčků se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14612,6 +14714,12 @@
     },
     "error.package-loading.last-path-component-of-checked-package-url-is-folder-containing-packages-itself.casks" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poskytnutá cesta k souboru vede do složky obsahující soudky místo balíčku.\nVás homebrew je rozbitý, tohle není chyba Corku"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14628,6 +14736,12 @@
     },
     "error.package-loading.last-path-component-of-checked-package-url-is-folder-containing-packages-itself.formulae" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poskytnutá cesta k souboru vede do složky obsahující vzorce místo balíčku.\nVás homebrew je rozbitý, tohle není chyba Corku"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14848,6 +14962,12 @@
     },
     "error.regex.nothing-matched" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REGEX nic nenašel"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -13453,6 +13453,12 @@
     },
     "debug.action.activate-demo" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Aktivovat demo"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13601,6 +13607,12 @@
     },
     "error.brewfile.importing.could-not-get-selected-brewfile-location" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při hledání adresy tohoto souboru Brewfile se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13680,6 +13692,12 @@
     },
     "error.data-downloading.invalid-response.%lld" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Homebrew poskytnul chybnou odezvu: %lld"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13736,6 +13754,12 @@
     },
     "error.data-downloading.invalid-url" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poskytnutá adresa není platnou adresou Homebrew serveru"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13764,6 +13788,12 @@
     },
     "error.data-downloading.no-data-received" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Homebrew při načítání nejoblíbenějších balíčků nevrátil odpověď"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13792,6 +13822,12 @@
     },
     "error.finder-reveal.could-not-find-package-in-parent" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při hledání žádaného balíčku ve složce se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13922,6 +13958,12 @@
     },
     "error.json-parsing.could-not-convert-string-to-data.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při převodu datového typu String do Data se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14032,6 +14074,12 @@
     },
     "error.licensing.timed-out" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Připojení k licenčnímu serveru vypršelo"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14054,6 +14102,12 @@
     },
     "error.maintenance.cache-purging.command-failed" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při mazání mezipaměti se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14098,6 +14152,12 @@
     },
     "error.maintenance.orphan-removal.could-not-get-number-of-uninstalled-orphans" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při počítání balíčků, které by tímto byly odstraněny, se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14181,6 +14241,12 @@
     },
     "error.outdated-packages.could-not-decode-command-output.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při dekódování JSON se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14209,6 +14275,12 @@
     },
     "error.outdated-packages.home-not-set" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametr HOME není pro Homebrew příkazy správně nastaven"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14237,6 +14309,12 @@
     },
     "error.outdated-packages.other-error.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při načítání zastaralých balíčků se vyskytla neimplementovaná chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14349,6 +14427,12 @@
     },
     "error.package-loading.%@-not-a-folder" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ není balíček"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14434,6 +14518,12 @@
     "error.package-loading.could-not-load-%@-at-%@-because-%@" : {
       "comment" : "Couldn't load package (package name) at (package URL) because (failure reason)",
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při načítání balíčku %1$@ (%2$@) se vyskytla chyba: %3$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14466,6 +14556,12 @@
     },
     "error.package-loading.could-not-load-packages.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při načítání balíčků se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14684,6 +14780,12 @@
     },
     "error.package-retrieval.uuid.could-not-find-any-packages-in-tracker" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poskytnuté UUID balíčku nebylo nalezeno"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14712,6 +14814,12 @@
     },
     "error.permissions.could-not-obtain-folder-access-permissions.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepovedlo se získat oprávnění k přístupu do složky: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14972,6 +15080,12 @@
     },
     "error.services.stopping.could-not-stop-service.%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při ukončování služby se vyskytla chyba: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15017,6 +15131,12 @@
     },
     "error.tap.untap.could-not-untap.tap-%@.failure-reason-%@" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při odstraňování pípy %1$@ se vyskytla chyba: %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15187,6 +15307,12 @@
     },
     "error.top-packages.impossible-error" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žádaný balíček nebyl nalezen, i když měl být"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37899,6 +38025,12 @@
     },
     "start-page.loading.failed.title" : {
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při načítání zastaralých balíčků se vyskytla chyba"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -13500,7 +13500,6 @@
       }
     },
     "debug.navigation" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -14340,12 +14339,6 @@
             "value" : "Package %@ does not have any versions installed"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.%@-does-not-have-any-versions-installed"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14360,12 +14353,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ is not a package folder"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.%@-not-a-folder"
           }
         },
         "zh-Hans" : {
@@ -14445,22 +14432,17 @@
       }
     },
     "error.package-loading.could-not-load-%@-at-%@-because-%@" : {
+      "comment" : "Couldn't load package (package name) at (package URL) because (failure reason)",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Couldn't load package%1$@ (%2$@):\n%3$@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.could-not-load-%1$@-at-%2$@-because-%3$@"
+            "value" : "Couldn't load package %1$@ (%2$@):\n%3$@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "无法加载软件包 %1$@ (%2$@):  %3$@"
           }
         }
@@ -14472,12 +14454,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Couldn't load packages"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.could-not-load-packages"
           }
         },
         "zh-Hans" : {
@@ -14494,12 +14470,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Couldn't load packages:\n%@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.could-not-load-packages.%@"
           }
         },
         "zh-Hans" : {
@@ -14552,12 +14522,6 @@
             "value" : "The specified path points to the Cask folder itself, not a package.\nYour Homebrew is broken, this is not a Cork issue"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.last-path-component-of-checked-package-url-is-folder-containing-packages-itself.casks"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14572,12 +14536,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The specified path points to the Formulae folder itself, not a package.\nYour Homebrew is broken, this is not a Cork issue"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "error.package-loading.last-path-component-of-checked-package-url-is-folder-containing-packages-itself.formulae"
           }
         },
         "zh-Hans" : {
@@ -37945,12 +37903,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Couldn't check for outdated packges"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "start-page.loading.failed.title"
           }
         }
       }

--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -14522,6 +14522,7 @@
       }
     },
     "error.package-loading.%@-not-a-folder" : {
+      "comment" : "Package folder in this context means a folder that encloses package versions. Every package has its own folder, and this error occurs when the provided URL does not point to a folder that encloses package versions",
       "localizations" : {
         "cs" : {
           "stringUnit" : {

--- a/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
+++ b/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
@@ -26,7 +26,7 @@ enum PackageLoadingError: LocalizedError
                 return String(localized: "error.package-loading.could-not-load-packages")
             }
         case .failedWhileLoadingCertainPackage(let string, let uRL, let failureReason):
-            return String(localized: "error.package-loading.could-not-load-\(string)-at-\(uRL.absoluteString)-because-\(failureReason)")
+            return String(localized: "error.package-loading.could-not-load-\(string)-at-\(uRL.absoluteString)-because-\(failureReason)", comment: "Couldn't load package (package name) at (package URL) because (failure reason)")
         case .packageDoesNotHaveAnyVersionsInstalled(let string):
             return String(localized: "error.package-loading.\(string)-does-not-have-any-versions-installed")
         case .packageIsNotAFolder(let string, _):

--- a/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
+++ b/Cork/Logic/File System/File Browser/Get Contents of Folder.swift
@@ -30,7 +30,7 @@ enum PackageLoadingError: LocalizedError
         case .packageDoesNotHaveAnyVersionsInstalled(let string):
             return String(localized: "error.package-loading.\(string)-does-not-have-any-versions-installed")
         case .packageIsNotAFolder(let string, _):
-            return String(localized: "error.package-loading.\(string)-not-a-folder")
+            return String(localized: "error.package-loading.\(string)-not-a-folder", comment: "Package folder in this context means a folder that encloses package versions. Every package has its own folder, and this error occurs when the provided URL does not point to a folder that encloses package versions")
         }
     }
 }

--- a/Cork/Models/JSON/Tap Codable Model.swift
+++ b/Cork/Models/JSON/Tap Codable Model.swift
@@ -50,4 +50,9 @@ struct TapInfo: Codable
 
     /// IDK
     let customRemote: Bool?
+    
+    var numberOfPackages: Int
+    {
+        return self.formulaNames.count + self.caskTokens.count
+    }
 }

--- a/Cork/Views/Packages/Package Details/Package Details.swift
+++ b/Cork/Views/Packages/Package Details/Package Details.swift
@@ -44,6 +44,22 @@ struct PackageDetailView: View, Sendable
         }
     }
 
+    private var formContent: some View {
+        FullSizeGroupedForm
+        {
+            BasicPackageInfoView(
+                package: package,
+                packageDetails: packageDetails!,
+                isLoadingDetails: isLoadingDetails,
+                isShowingExpandedCaveats: $isShowingExpandedCaveats
+            )
+            
+            PackageDependencies(dependencies: packageDetails?.dependencies, isDependencyDisclosureGroupExpanded: $isShowingExpandedDependencies)
+            
+            PackageSystemInfo(package: package)
+        }
+    }
+    
     var body: some View
     {
         VStack(alignment: .leading, spacing: 0)
@@ -70,20 +86,11 @@ struct PackageDetailView: View, Sendable
                 }
                 else
                 {
-                    FullSizeGroupedForm
-                    {
-                        BasicPackageInfoView(
-                            package: package,
-                            packageDetails: packageDetails!,
-                            isLoadingDetails: isLoadingDetails,
-                            isShowingExpandedCaveats: $isShowingExpandedCaveats
-                        )
-
-                        PackageDependencies(dependencies: packageDetails?.dependencies, isDependencyDisclosureGroupExpanded: $isShowingExpandedDependencies)
-
-                        PackageSystemInfo(package: package)
+                    if #available(macOS 13.3, *) {
+                        formContent.scrollBounceBehavior(.basedOnSize)
+                    } else {
+                        formContent.scrollDisabled(isScrollingDisabled)
                     }
-                    .scrollDisabled(isScrollingDisabled)
                 }
             }
 

--- a/Cork/Views/Taps/Tap Details/Sub-Views/Tap Info.swift
+++ b/Cork/Views/Taps/Tap Details/Sub-Views/Tap Info.swift
@@ -10,33 +10,28 @@ import SwiftUI
 struct TapDetailsInfo: View
 {
     let tap: BrewTap
-    let isOfficial: Bool
-
-    let includedFormulae: [String]
-    let includedCasks: [String]
-
-    let numberOfPackages: Int
-    let homepage: URL?
+    
+    var tapInfo: TapInfo
 
     var roughPackageOverview: LocalizedStringResource
     {
-        if includedFormulae.isEmpty && includedCasks.isEmpty
+        if tapInfo.formulaNames.isEmpty && tapInfo.caskTokens.isEmpty
         {
             return "tap-details.contents.none"
         }
-        else if !includedFormulae.isEmpty && includedCasks.isEmpty
+        else if !tapInfo.formulaNames.isEmpty && tapInfo.caskTokens.isEmpty
         {
             return "tap-details.contents.formulae-only"
         }
-        else if !includedCasks.isEmpty && includedFormulae.isEmpty
+        else if !tapInfo.caskTokens.isEmpty && tapInfo.formulaNames.isEmpty
         {
             return "tap-details.contents.casks-only"
         }
-        else if includedFormulae.count > includedCasks.count
+        else if tapInfo.formulaNames.count > tapInfo.caskTokens.count
         {
             return "tap-details.contents.formulae-mostly"
         }
-        else if includedFormulae.count < includedCasks.count
+        else if tapInfo.formulaNames.count < tapInfo.caskTokens.count
         {
             return "tap-details.contents.casks-mostly"
         }
@@ -59,12 +54,12 @@ struct TapDetailsInfo: View
 
             LabeledContent
             {
-                Text(numberOfPackages.formatted())
+                Text(tapInfo.numberOfPackages.formatted())
             } label: {
                 Text("tap-details.package-count")
             }
 
-            if let homepage
+            if let homepage = tapInfo.remote
             {
                 LabeledContent
                 {
@@ -79,7 +74,7 @@ struct TapDetailsInfo: View
         } header: {
             VStack(alignment: .leading, spacing: 15)
             {
-                TapDetailsTitle(tap: tap, isOfficial: isOfficial)
+                TapDetailsTitle(tap: tap, isOfficial: tapInfo.official)
 
                 Text("tap-details.info")
                     .font(.title2)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
 files:
-  - source: Localizable.xcstrings
-    translation: Localizable.xcstrings
+  - source: /Cork/Localizable.xcstrings
+    translation: /Cork/Localizable.xcstrings
     multilingual: 1


### PR DESCRIPTION
When viewing the list of outdated packages, it can be useful to quickly know what a packge does or other info about it. This adds an info button beside each package name that opens a popover rendering the existing Package Details View.
