### PR TITLE
Pass down some environment variables to make Cork work well with brew mirrors

### DIFF
--- a/Cork/Logic/Shell/Shell Interface.swift
+++ b/Cork/Logic/Shell/Shell Interface.swift
@@ -69,6 +69,17 @@ func shell(
         finalEnvironment = ["HOME": FileManager.default.homeDirectoryForCurrentUser.path]
     }
 
+    // MARK: - Set up mirrors if the environment variables exist
+
+    if let brewApiDomain = ProcessInfo.processInfo.environment["HOMEBREW_API_DOMAIN"]
+    {
+        finalEnvironment["HOMEBREW_API_DOMAIN"] = brewApiDomain
+    }
+    if let brewBottleDomain = ProcessInfo.processInfo.environment["HOMEBREW_BOTTLE_DOMAIN"]
+    {
+        finalEnvironment["HOMEBREW_BOTTLE_DOMAIN"] = brewBottleDomain
+    }
+
     // MARK: - Set up proxy if it's enabled
 
     if let proxySettings = AppConstants.proxySettings


### PR DESCRIPTION
Basically, when executing brew commands, this will pass down HOMEBREW_API_DOMAIN and HOMEBREW_BOTTLE_DOMAIN from the system environment.

As for the way to make use of this feature, you need to set variables through `launchctl setenv`, this can be done through macOS Automator or LaunchAgents, i.e. [LaunchAgent Approach](https://superuser.com/questions/476752/setting-environment-variables-in-os-x-for-gui-applications/476960#476960)

