### PR TITLE
^ Optional Formulae.Bottle.Stable in JSON decoding

### DIFF
--- a/Cork/Logic/Packages/Load Up Package Info.swift
+++ b/Cork/Logic/Packages/Load Up Package Info.swift
@@ -98,7 +98,7 @@ extension BrewPackage
                 }
 
                 /// The stable files
-                let stable: Stable
+                let stable: Stable?
             }
 
             /// Info about the relevant files
@@ -130,9 +130,14 @@ extension BrewPackage
                 }
             }
 
-            func getCompatibility() -> Bool
+            func getCompatibility() -> Bool?
             {
-                for compatibleSystem in bottle.stable.files.keys
+                guard let stable = bottle.stable else
+                {
+                    AppConstants.shared.logger.debug("Package \(name) has unknown compatibility")
+                    return nil
+                }
+                for compatibleSystem in stable.files.keys
                 {
                     if compatibleSystem.contains(AppConstants.shared.osVersionString.lookupName)
                     {

--- a/Cork/Models/Packages/Brew Package Details.swift
+++ b/Cork/Models/Packages/Brew Package Details.swift
@@ -39,7 +39,7 @@ class BrewPackageDetails: ObservableObject
     let outdated: Bool
     let caveats: String?
 
-    let isCompatible: Bool
+    let isCompatible: Bool?
 
     // MARK: - Mutable properties
 
@@ -48,7 +48,7 @@ class BrewPackageDetails: ObservableObject
 
     // MARK: - Init
 
-    init(name: String, description: String?, homepage: URL, tap: BrewTap, installedAsDependency: Bool, dependents: [String]? = nil, dependencies: [BrewPackageDependency]? = nil, outdated: Bool, caveats: String? = nil, pinned: Bool, isCompatible: Bool)
+    init(name: String, description: String?, homepage: URL, tap: BrewTap, installedAsDependency: Bool, dependents: [String]? = nil, dependencies: [BrewPackageDependency]? = nil, outdated: Bool, caveats: String? = nil, pinned: Bool, isCompatible: Bool?)
     {
         self.name = name
         self.description = description


### PR DESCRIPTION
Previously, an error would occur during decoding when the `formulae.bottle` key was empty, thereby preventing the package details view from being shown.

The struct now represents this possibility as an optional, allowing this key to decode correctly when empty (in which case it will be ignored).

For example, `arena` from [this tap](https://github.com/finestructure/homebrew-tap) returns an otherwise well-formed JSON response with an empty `formulae.bottle` value.