### PR TITLE
~ Reveal in Finder implementation

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -17329,6 +17329,7 @@
       }
     },
     "error.finder-reveal.could-not-find-package-in-parent" : {
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -17370,6 +17371,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法在父文件夹中找到所要求的软件包"
+          }
+        }
+      }
+    },
+    "error.finder-reveal.no-url" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Package has no URL"
           }
         }
       }

--- a/Cork/Logic/Package Loading/Load Up Installed Packages.swift
+++ b/Cork/Logic/Package Loading/Load Up Installed Packages.swift
@@ -223,7 +223,7 @@ private extension BrewDataStorage
                         installedOn: packageURL.creationDate,
                         versions: versionNamesForPackage,
                         installedIntentionally: wasPackageInstalledIntentionally,
-                        sizeInBytes: packageURL.directorySize
+                        url: packageURL
                     )
                 )
 

--- a/Cork/Logic/Search for Package by ID.swift
+++ b/Cork/Logic/Search for Package by ID.swift
@@ -64,7 +64,7 @@ extension UUID
                 throw TopPackageRetrievalError.resultingArrayWasEmptyEvenThoughPackagesWereInIt
             }
             
-            return .init(name: foundTopFormula.packageName, type: .formula, installedOn: nil, versions: [], sizeInBytes: nil)
+            return .init(name: foundTopFormula.packageName, type: .formula, installedOn: nil, versions: [], url: nil)
         }
         else
         {
@@ -74,7 +74,7 @@ extension UUID
                 throw TopPackageRetrievalError.resultingArrayWasEmptyEvenThoughPackagesWereInIt
             }
             
-            return .init(name: foundTopCask.packageName, type: .cask, installedOn: nil, versions: [], sizeInBytes: nil)
+            return .init(name: foundTopCask.packageName, type: .cask, installedOn: nil, versions: [], url: nil)
         }
     }
 }

--- a/Cork/Models/Package Installation/Installation Progress Tracker.swift
+++ b/Cork/Models/Package Installation/Installation Progress Tracker.swift
@@ -10,7 +10,7 @@ import CorkShared
 
 class InstallationProgressTracker: ObservableObject
 {
-    @Published var packageBeingInstalled: PackageInProgressOfBeingInstalled = .init(package: .init(name: "", type: .formula, installedOn: nil, versions: [], sizeInBytes: 0), installationStage: .downloadingCask, packageInstallationProgress: 0)
+    @Published var packageBeingInstalled: PackageInProgressOfBeingInstalled = .init(package: .init(name: "", type: .formula, installedOn: nil, versions: [], url: nil), installationStage: .downloadingCask, packageInstallationProgress: 0)
 
     @Published var numberOfPackageDependencies: Int = 0
     @Published var numberInLineOfPackageCurrentlyBeingFetched: Int = 0

--- a/Cork/Models/Package Uninstallation/Uninstallation Confirmation Tracker.swift
+++ b/Cork/Models/Package Uninstallation/Uninstallation Confirmation Tracker.swift
@@ -13,7 +13,7 @@ class UninstallationConfirmationTracker: ObservableObject
 {
     @Published var isShowingUninstallOrPurgeConfirmation: Bool = false
 
-    @Published private(set) var packageThatNeedsConfirmation: BrewPackage = .init(name: "", type: .formula, installedOn: Date(), versions: [], sizeInBytes: 0)
+    @Published private(set) var packageThatNeedsConfirmation: BrewPackage = .init(name: "", type: .formula, installedOn: Date(), versions: [], url: nil)
     @Published private(set) var shouldPurge: Bool = false
     @Published private(set) var isCalledFromSidebar: Bool = false
 
@@ -33,6 +33,6 @@ class UninstallationConfirmationTracker: ObservableObject
             isShowingUninstallOrPurgeConfirmation = false
         }
 
-        packageThatNeedsConfirmation = .init(name: "", type: .formula, installedOn: Date(), versions: [], sizeInBytes: 0)
+        packageThatNeedsConfirmation = .init(name: "", type: .formula, installedOn: Date(), versions: [], url: nil)
     }
 }

--- a/Cork/Models/Packages/Brew Package.swift
+++ b/Cork/Models/Packages/Brew Package.swift
@@ -111,50 +111,24 @@ struct BrewPackage: Identifiable, Equatable, Hashable, Codable
     {
         enum FinderRevealError: LocalizedError
         {
-            case couldNotFindPackageInParent
+            case noURL
 
             var errorDescription: String?
             {
-                return String(localized: "error.finder-reveal.could-not-find-package-in-parent")
+                return String(localized: "error.finder-reveal.no-url")
             }
         }
-
-        var packageURL: URL?
-        var packageLocationParent: URL
+        
+        guard let url = url else
         {
-            if type == .formula
-            {
-                return AppConstants.shared.brewCellarPath
-            }
-            else
-            {
-                return AppConstants.shared.brewCaskPath
-            }
-        }
-
-        do
-        {
-            let contentsOfParentFolder: [URL] = try FileManager.default.contentsOfDirectory(at: packageLocationParent, includingPropertiesForKeys: [.isDirectoryKey])
-            
-            packageURL = contentsOfParentFolder.filter
-            {
-                $0.lastPathComponent.contains(name)
-            }.first
-            
-            guard let packageURL
-            else
-            {
-                throw FinderRevealError.couldNotFindPackageInParent
-            }
-            
-            packageURL.revealInFinder(.openParentDirectoryAndHighlightTarget)
-        }
-        catch let finderRevealError
-        {
+            let finderRevealError: FinderRevealError = .noURL
             AppConstants.shared.logger.error("Failed while revealing package: \(finderRevealError.localizedDescription)")
             /// Play the error sound
             NSSound(named: "ping")?.play()
+            throw finderRevealError
         }
+            
+        url.revealInFinder(.openParentDirectoryAndHighlightTarget)
     }
 }
 

--- a/Cork/Models/Packages/Brew Package.swift
+++ b/Cork/Models/Packages/Brew Package.swift
@@ -13,6 +13,20 @@ import CorkShared
 /// A representation of a Homebrew package
 struct BrewPackage: Identifiable, Equatable, Hashable, Codable
 {
+    final private class SizeCache: Identifiable, Equatable, Hashable, Codable, @unchecked Sendable
+    {
+        static func == (lhs: BrewPackage.SizeCache, rhs: BrewPackage.SizeCache) -> Bool
+        {
+            lhs.size == rhs.size
+        }
+        func hash(into hasher: inout Hasher)
+        {
+            hasher.combine(size)
+        }
+        
+        var size: Int64? = nil
+    }
+    
     var id: UUID = .init()
     let name: String
 
@@ -61,7 +75,14 @@ struct BrewPackage: Identifiable, Equatable, Hashable, Codable
 
     var installedIntentionally: Bool = true
 
-    let sizeInBytes: Int64?
+    let url: URL?
+    private let sizeCache: SizeCache = .init()
+    var sizeInBytes: Int64?
+    {
+        if let size = sizeCache.size { return size }
+        sizeCache.size = url?.directorySize
+        return sizeCache.size
+    }
 
     var isBeingModified: Bool = false
 

--- a/Cork/Views/Installation/Reusables/Search Result Row.swift
+++ b/Cork/Views/Installation/Reusables/Search Result Row.swift
@@ -125,7 +125,7 @@ struct SearchResultRow: View, Sendable
 
                     do
                     {
-                        let searchedForPackage: BrewPackage = .init(name: searchedForPackage.name, type: searchedForPackage.type, installedOn: Date(), versions: [], sizeInBytes: nil)
+                        let searchedForPackage: BrewPackage = .init(name: searchedForPackage.name, type: searchedForPackage.type, installedOn: Date(), versions: [], url: nil)
 
                         do
                         {

--- a/Cork/Views/Installation/Sub-Views/Initial/Top Packages Section.swift
+++ b/Cork/Views/Installation/Sub-Views/Initial/Top Packages Section.swift
@@ -42,7 +42,7 @@ struct TopPackagesSection: View
             {
                 ForEach(packages.prefix(15))
                 { topPackage in
-                    SearchResultRow(searchedForPackage: BrewPackage(name: topPackage.packageName, type: trackerType, installedOn: nil, versions: [], sizeInBytes: nil), context: .topPackages, downloadCount: topPackage.packageDownloads)
+                    SearchResultRow(searchedForPackage: BrewPackage(name: topPackage.packageName, type: trackerType, installedOn: nil, versions: [], url: nil), context: .topPackages, downloadCount: topPackage.packageDownloads)
                 }
             }
         } header: {

--- a/Cork/Views/Installation/Sub-Views/Searching.swift
+++ b/Cork/Views/Installation/Sub-Views/Searching.swift
@@ -28,11 +28,11 @@ struct InstallationSearchingView: View, Sendable
 
                 for formula in await foundFormulae
                 {
-                    searchResultTracker.foundFormulae.append(BrewPackage(name: formula, type: .formula, installedOn: nil, versions: [], sizeInBytes: nil))
+                    searchResultTracker.foundFormulae.append(BrewPackage(name: formula, type: .formula, installedOn: nil, versions: [], url: nil))
                 }
                 for cask in await foundCasks
                 {
-                    searchResultTracker.foundCasks.append(BrewPackage(name: cask, type: .cask, installedOn: nil, versions: [], sizeInBytes: nil))
+                    searchResultTracker.foundCasks.append(BrewPackage(name: cask, type: .cask, installedOn: nil, versions: [], url: nil))
                 }
 
                 packageInstallationProcessStep = .presentingSearchResults

--- a/Cork/Views/Reusables/Buttons/Preview Package.swift
+++ b/Cork/Views/Reusables/Buttons/Preview Package.swift
@@ -18,7 +18,7 @@ struct PreviewPackageButton: View
     {
         Button
         {
-            let constructedPackage: BrewPackage = .init(name: packageNameToPreview, type: .formula, installedOn: nil, versions: [], sizeInBytes: nil)
+            let constructedPackage: BrewPackage = .init(name: packageNameToPreview, type: .formula, installedOn: nil, versions: [], url: nil)
             
             openWindow(value: constructedPackage)
         } label: {

--- a/Cork/Views/Updating/Incremental Updating/Update Some Packages View.swift
+++ b/Cork/Views/Updating/Incremental Updating/Update Some Packages View.swift
@@ -15,7 +15,7 @@ struct UpdateSomePackagesView: View
     @EnvironmentObject var outdatedPackageTracker: OutdatedPackageTracker
 
     @State private var packageUpdatingStage: PackageUpdatingStage = .updating
-    @State private var packageBeingCurrentlyUpdated: BrewPackage = .init(name: "", type: .formula, installedOn: nil, versions: [], sizeInBytes: nil)
+    @State private var packageBeingCurrentlyUpdated: BrewPackage = .init(name: "", type: .formula, installedOn: nil, versions: [], url: nil)
     @State private var updateProgress: Double = 0.0
 
     @State private var packageUpdatingErrors: [String] = .init()


### PR DESCRIPTION
Previously, a package's Reveal in Finder method would find its URL from scratch.
Now that a URL property is present, this is no longer necessary.

Depends on #449