### PR TITLE
+ Option to automatically accept package EULAs

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -41785,6 +41785,17 @@
         }
       }
     },
+    "settings.install-uninstall.installation.automatically-accept-eulas" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatically accept package EULAs"
+          }
+        }
+      }
+    },
     "settings.install-uninstall.installation.enable-automatic-cleanup" : {
       "localizations" : {
         "cs" : {

--- a/Cork/Logic/Shell/Shell Interface.swift
+++ b/Cork/Logic/Shell/Shell Interface.swift
@@ -94,6 +94,11 @@ func shell(
     {
         finalEnvironment["HOMEBREW_NO_INSTALL_CLEANUP"] = "TRUE"
     }
+    
+    // MARK: - Automatically accept EULA if enabled
+    if UserDefaults.standard.bool(forKey: "automaticallyAcceptEULA") {
+        finalEnvironment["HOMEBREW_ACCEPT_EULA"] = "Y"
+    }
 
     AppConstants.shared.logger.debug("Final environment: \(finalEnvironment)")
 

--- a/Cork/Views/Settings/Panes/Installation Pane.swift
+++ b/Cork/Views/Settings/Panes/Installation Pane.swift
@@ -20,6 +20,8 @@ struct InstallationAndUninstallationPane: View
 
     @AppStorage("showRealTimeTerminalOutputOfOperations") var showRealTimeTerminalOutputOfOperations: Bool = false
     @AppStorage("openRealTimeTerminalOutputByDefault") var openRealTimeTerminalOutputByDefault: Bool = false
+    
+    @AppStorage("automaticallyAcceptEULA") var automaticallyAcceptEULA: Bool = false
 
     @AppStorage("allowMoreCompleteUninstallations") var allowMoreCompleteUninstallations: Bool = false
 
@@ -101,6 +103,11 @@ struct InstallationAndUninstallationPane: View
                             }
                             .disabled(!showRealTimeTerminalOutputOfOperations)
                             .padding(.leading)
+                        }
+                        
+                        Toggle(isOn: $automaticallyAcceptEULA)
+                        {
+                            Text("settings.install-uninstall.installation.automatically-accept-eulas")
                         }
 
                         VStack(alignment: .leading)


### PR DESCRIPTION
Partial fix for #305.

This PR adds an option that sets the `HOMEBREW_ACCEPT_EULA` environment variable.
If enabled, installation proceeds without requesting input on packages that require accepting a EULA (such as `microsoft/mssql-release/msodbcsql18`).

This PR does not change the way that inter-process IO is managed—
Thus, if the user attempts to install such a package with the option disabled, it will still hang indefinitely.