### PR TITLE
^ Unloaded package number formatting (English)

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -47520,7 +47520,7 @@
               },
               "one" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "Jeden vzorec se nepodařilo načíst"
                 }
               },
@@ -47539,7 +47539,7 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "There’s one Formula that couldn’t be loaded"
+                  "value" : "There’s %lld Formula that couldn’t be loaded"
                 }
               },
               "other" : {
@@ -47568,7 +47568,7 @@
               },
               "one" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "1 приложение/библиотеку не удалось загрузить"
                 }
               },


### PR DESCRIPTION
When there is exactly one unloaded cask, it now displays as a number ("1") instead of as a word ("one") to match how unloaded formulae are displayed in English.

Before:
![Screenshot 2025-02-04 at 17 59 17](https://github.com/user-attachments/assets/bebe894a-b3d6-43e8-bc39-b10d83679bae)

After:
![Screenshot 2025-02-04 at 17 59 05](https://github.com/user-attachments/assets/e55c798e-fb74-4ae5-bad3-4897a3adf6f0)
