### PR TITLE
^ Zombie process when installation cancelled

### DIFF
--- a/Cork/Logic/Shell/Shell Interface.swift
+++ b/Cork/Logic/Shell/Shell Interface.swift
@@ -53,7 +53,115 @@ func shell(
     workingDirectory: URL? = nil
 ) -> AsyncStream<StreamedTerminalOutput>
 {
-    shell(launchPath, arguments, environment: environment, workingDirectory: workingDirectory).stream
+    let task: Process = .init()
+    
+    var finalEnvironment: [String: String] = .init()
+    
+    // MARK: - Set up the $HOME environment variable so brew commands work on versions 4.1 and up
+    
+    if var environment
+    {
+        environment["HOME"] = FileManager.default.homeDirectoryForCurrentUser.path
+        finalEnvironment = environment
+    }
+    else
+    {
+        finalEnvironment = ["HOME": FileManager.default.homeDirectoryForCurrentUser.path]
+    }
+    
+    // MARK: - Set up mirrors if the environment variables exist
+    
+    if let brewApiDomain = ProcessInfo.processInfo.environment["HOMEBREW_API_DOMAIN"]
+    {
+        finalEnvironment["HOMEBREW_API_DOMAIN"] = brewApiDomain
+    }
+    if let brewBottleDomain = ProcessInfo.processInfo.environment["HOMEBREW_BOTTLE_DOMAIN"]
+    {
+        finalEnvironment["HOMEBREW_BOTTLE_DOMAIN"] = brewBottleDomain
+    }
+    
+    // MARK: - Set up proxy if it's enabled
+    
+    if let proxySettings = AppConstants.shared.proxySettings
+    {
+        AppConstants.shared.logger.info("Proxy is enabled")
+        finalEnvironment["ALL_PROXY"] = "\(proxySettings.host):\(proxySettings.port)"
+    }
+    
+    // MARK: - Block automatic cleanup is configured
+    
+    if !UserDefaults.standard.bool(forKey: "isAutomaticCleanupEnabled")
+    {
+        finalEnvironment["HOMEBREW_NO_INSTALL_CLEANUP"] = "TRUE"
+    }
+    
+    AppConstants.shared.logger.debug("Final environment: \(finalEnvironment)")
+    
+    // MARK: - Set working directory if provided
+    
+    if let workingDirectory
+    {
+        AppConstants.shared.logger.info("Working directory configured: \(workingDirectory)")
+        task.currentDirectoryURL = workingDirectory
+    }
+    
+    let sudoHelperURL: URL = Bundle.main.resourceURL!.appendingPathComponent("Sudo Helper", conformingTo: .executable)
+    
+    finalEnvironment["SUDO_ASKPASS"] = sudoHelperURL.path
+    
+    task.environment = finalEnvironment
+    task.launchPath = launchPath.absoluteString
+    task.arguments = arguments
+    
+    let pipe: Pipe = .init()
+    task.standardOutput = pipe
+    
+    let errorPipe: Pipe = .init()
+    task.standardError = errorPipe
+    
+    do
+    {
+        try task.run()
+    }
+    catch
+    {
+        AppConstants.shared.logger.error("\(String(describing: error))")
+    }
+    
+    return AsyncStream
+    { continuation in
+        pipe.fileHandleForReading.readabilityHandler = { handler in
+            guard let standardOutput = String(data: handler.availableData, encoding: .utf8)
+            else
+            {
+                return
+            }
+            
+            guard !standardOutput.isEmpty
+            else
+            {
+                return
+            }
+            
+            continuation.yield(.standardOutput(standardOutput))
+        }
+        
+        errorPipe.fileHandleForReading.readabilityHandler = { handler in
+            guard let errorOutput = String(data: handler.availableData, encoding: .utf8)
+            else
+            {
+                return
+            }
+            
+            guard !errorOutput.isEmpty else { return }
+            
+            continuation.yield(.standardError(errorOutput))
+        }
+        
+        task.terminationHandler = { _ in
+            continuation.finish()
+        }
+    }
 }
 
 func shell(

--- a/Cork/Logic/Shell/Shell Interface.swift
+++ b/Cork/Logic/Shell/Shell Interface.swift
@@ -53,6 +53,16 @@ func shell(
     workingDirectory: URL? = nil
 ) -> AsyncStream<StreamedTerminalOutput>
 {
+    shell(launchPath, arguments, environment: environment, workingDirectory: workingDirectory).stream
+}
+
+func shell(
+    _ launchPath: URL,
+    _ arguments: [String],
+    environment: [String: String]? = nil,
+    workingDirectory: URL? = nil
+) -> (stream: AsyncStream<StreamedTerminalOutput>, process: Process)
+{
     let task: Process = .init()
 
     var finalEnvironment: [String: String] = .init()
@@ -128,7 +138,7 @@ func shell(
         AppConstants.shared.logger.error("\(String(describing: error))")
     }
 
-    return AsyncStream
+    let stream: AsyncStream<StreamedTerminalOutput> = AsyncStream
     { continuation in
         pipe.fileHandleForReading.readabilityHandler = { handler in
             guard let standardOutput = String(data: handler.availableData, encoding: .utf8)
@@ -162,4 +172,5 @@ func shell(
             continuation.finish()
         }
     }
+    return (stream, task)
 }

--- a/Cork/Models/Package Installation/Installation Progress Tracker.swift
+++ b/Cork/Models/Package Installation/Installation Progress Tracker.swift
@@ -15,10 +15,26 @@ class InstallationProgressTracker: ObservableObject
     @Published var numberOfPackageDependencies: Int = 0
     @Published var numberInLineOfPackageCurrentlyBeingFetched: Int = 0
     @Published var numberInLineOfPackageCurrentlyBeingInstalled: Int = 0
+    
+    private var installationProcess: Process?
 
     private var showRealTimeTerminalOutputs: Bool
     {
         UserDefaults.standard.bool(forKey: "showRealTimeTerminalOutputOfOperations")
+    }
+    
+    deinit
+    {
+        cancel()
+    }
+    
+    @discardableResult
+    func cancel() -> Bool
+    {
+        guard let installationProcess else {return false}
+        installationProcess.terminate()
+        self.installationProcess = nil
+        return true
     }
 
     @MainActor
@@ -71,7 +87,9 @@ class InstallationProgressTracker: ObservableObject
 
         AppConstants.shared.logger.info("Package \(package.name, privacy: .public) is Formula")
 
-        for await output in shell(AppConstants.shared.brewExecutablePath, ["install", package.name])
+        let (stream, process): (AsyncStream<StreamedTerminalOutput>, Process) = shell(AppConstants.shared.brewExecutablePath, ["install", package.name])
+        installationProcess = process
+        for await output in stream
         {
             switch output
             {
@@ -186,7 +204,9 @@ class InstallationProgressTracker: ObservableObject
         AppConstants.shared.logger.info("Package is Cask")
         AppConstants.shared.logger.debug("Installing package \(package.name, privacy: .public)")
 
-        for await output in shell(AppConstants.shared.brewExecutablePath, ["install", "--no-quarantine", package.name])
+        let (stream, process): (AsyncStream<StreamedTerminalOutput>, Process) = shell(AppConstants.shared.brewExecutablePath, ["install", "--no-quarantine", package.name])
+        installationProcess = process
+        for await output in stream
         {
             switch output
             {

--- a/Cork/Views/Installation/Install Package.swift
+++ b/Cork/Views/Installation/Install Package.swift
@@ -147,6 +147,7 @@ struct AddFormulaView: View
                             AsyncButton
                             {
                                 dismiss()
+                                installationProgressTracker.cancel()
                                 
                                 do
                                 {


### PR DESCRIPTION
Previously, cancelling an installation would not terminate the child process.
So, if Brew were to hang (eg due to waiting for input), it would remain as a zombie until manually killed via Activity Monitor or the like.

Due to Brew's locking mechanisms, this also means that no other process would be able to access the package in question.

To prevent this, a `shell` overload returning the spawned process has now been added, allowing InstallationProgressTracker to terminate it upon cancellation.