### PR TITLE
Quick-fix partial update sheet

### DIFF
--- a/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
+++ b/Cork/Views/Start Page/Sub-Views/Outdated Packages/Outdated Package List Box.swift
@@ -54,7 +54,7 @@ struct OutdatedPackageListBox: View
                                 {
                                     Button
                                     {
-                                        appState.isShowingIncrementalUpdateSheet = true
+                                        appState.showSheet(ofType: .partialUpdate)
                                     } label: {
                                         Text("start-page.update-incremental.package-count-\(packagesMarkedForUpdating.count)")
                                     }


### PR DESCRIPTION
Fixes the "Update x packages" button which is used when not all packages are selected for updating.

Previously this button would not show the expected sheet.

This is not a total solution—the partial update view is still not at parity with the full update view.