### PR TITLE
+  Improve popups layout performance, adaptive width and line breaks

### DIFF
--- a/Cork/Views/Installation/Sub-Views/Misc Views/Live Code Output.swift
+++ b/Cork/Views/Installation/Sub-Views/Misc Views/Live Code Output.swift
@@ -33,6 +33,8 @@ struct LiveTerminalOutputView: View
                         { line in
                             Text(line.line)
                                 .id(line.id)
+                                .lineLimit(nil)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                     }
                     .frame(minHeight: 200)

--- a/Cork/Views/Maintenance/Sub-Views/Maintenance Finished View.swift
+++ b/Cork/Views/Maintenance/Sub-Views/Maintenance Finished View.swift
@@ -74,10 +74,14 @@ struct MaintenanceFinishedView: View
             {
                 Text("maintenance.finished")
                     .font(.headline)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if shouldUninstallOrphans
                 {
                     Text("maintenance.results.orphans-count-\(numberOfOrphansRemoved)")
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if shouldPurgeCache
@@ -85,6 +89,8 @@ struct MaintenanceFinishedView: View
                     VStack(alignment: .leading)
                     {
                         Text("maintenance.results.package-cache")
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
 
                         if !displayablePackagesHoldingBackCachePurge.isEmpty
                         {
@@ -97,12 +103,16 @@ struct MaintenanceFinishedView: View
                                 Text("maintenance.results.package-cache.skipped-\(packageNamesNotTruncated.formatted(.list(type: .and)))-and-\(numberOfTruncatedPackages)-others")
                                     .font(.caption)
                                     .foregroundColor(Color(nsColor: NSColor.systemGray))
+                                    .lineLimit(nil)
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
                             else
                             {
                                 Text("maintenance.results.package-cache.skipped-\(displayablePackagesHoldingBackCachePurge.formatted(.list(type: .and)))")
                                     .font(.caption)
                                     .foregroundColor(Color(nsColor: NSColor.systemGray))
+                                    .lineLimit(nil)
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
                         }
 
@@ -133,9 +143,13 @@ struct MaintenanceFinishedView: View
                     VStack(alignment: .leading)
                     {
                         Text("maintenance.results.cached-downloads")
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text("maintenance.results.cached-downloads.summary-\(reclaimedSpaceAfterCachePurge.formatted(.byteCount(style: .file)))")
                             .font(.caption)
                             .foregroundColor(Color(nsColor: NSColor.systemGray))
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 
@@ -144,6 +158,8 @@ struct MaintenanceFinishedView: View
                     if brewHealthCheckFoundNoProblems
                     {
                         Text("maintenance.results.health-check.problems-none")
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     else
                     {
@@ -152,10 +168,12 @@ struct MaintenanceFinishedView: View
                             {
                                 maintenanceFoundNoProblems = false
                             }
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
             }
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
         }
         .task
         {

--- a/Cork/Views/Updating/Complete Updating/Sub-Views/States/Checking for Updates.swift
+++ b/Cork/Views/Updating/Complete Updating/Sub-Views/States/Checking for Updates.swift
@@ -25,6 +25,8 @@ struct CheckingForUpdatesStateView: View
         VStack(alignment: .leading)
         {
             Text("update-packages.updating.checking")
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
             LiveTerminalOutputView(
                 lineArray: $updateProgressTracker.realTimeOutput,
                 isRealTimeTerminalOutputExpanded: $isShowingRealTimeTerminalOutput,

--- a/Cork/Views/Updating/Complete Updating/Sub-Views/States/Updating Package Tracker.swift
+++ b/Cork/Views/Updating/Complete Updating/Sub-Views/States/Updating Package Tracker.swift
@@ -22,6 +22,8 @@ struct UpdatingPackageTrackerStateView: View
     var body: some View
     {
         Text("update-packages.updating.updating-outdated-package")
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
             .task
             {
                 do

--- a/Cork/Views/Updating/Complete Updating/Sub-Views/States/Updating Packages.swift
+++ b/Cork/Views/Updating/Complete Updating/Sub-Views/States/Updating Packages.swift
@@ -26,8 +26,12 @@ struct UpdatingPackagesStateView: View
             VStack(alignment: .leading, spacing: 3)
             {
                 Text("update-packages.updating.updating")
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 SubtitleText(text: updateProcessDetailsStage.currentStage.rawValue)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             LiveTerminalOutputView(

--- a/Cork/Views/Updating/Complete Updating/Update Packages View.swift
+++ b/Cork/Views/Updating/Complete Updating/Update Packages View.swift
@@ -74,7 +74,8 @@ struct UpdatePackagesView: View
             }
         }
         .padding()
-        .fixedSize()
+        .frame(minWidth: 350, maxWidth: 500)
+        .fixedSize(horizontal: false, vertical: true)
         .allAnimationsDisabled()
     }
 }


### PR DESCRIPTION
## 1. updating view

### before
<img width="505" alt="image" src="https://github.com/user-attachments/assets/87d12f46-984f-4793-8a87-2702ab286cc6" />

### after
<img width="584" alt="image" src="https://github.com/user-attachments/assets/2dd3fafe-14d1-4a4c-a858-4ef8f4210997" />

## 2. finished view

### before

![image](https://github.com/user-attachments/assets/68084e25-b2aa-4bdf-a431-4934b15aaa0b)

### after
<img width="572" alt="image" src="https://github.com/user-attachments/assets/2c51e467-58e7-470d-8de4-23b4bf8d4060" />
