### PR TITLE
Update German translations in Localizable.xcstrings

### DIFF
--- a/Cork/Localizable.xcstrings
+++ b/Cork/Localizable.xcstrings
@@ -23242,7 +23242,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@"
+            "value" : "Es ist ein Fehler beim Aktualisieren aufgetreten: %@"
           }
         },
         "en" : {
@@ -57526,7 +57526,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Es konnten keine veralteten Pakete überprüft werden."
+            "value" : "Es konnte nicht nach veralteten Paketen gesucht werden"
           }
         },
         "en" : {


### PR DESCRIPTION
I am sorry that my contribution is like "here and there some minor changes" - it is because I fix the labels as soon as I see them in Cork 😅 

This pull request updates German translations in the `Cork/Localizable.xcstrings` file to improve clarity and accuracy of error messages.

Localization improvements:

* Updated the German translation for the error message shown when an update fails to be more descriptive: changed from a generic placeholder to "Es ist ein Fehler beim Aktualisieren aufgetreten: %@".
* Revised the German translation for the message shown when outdated packages cannot be checked, making the wording clearer and more natural: changed to "Es konnte nicht nach veralteten Paketen gesucht werden".