### PR TITLE
Clarify situation about licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,4 @@ In my case, it was `echo "eval \"\$(/Users/david/.local/bin/mise activate zsh)\"
 
 Cork is licensed under [Commons Clause](https://commonsclause.com).
 
-This means that Cork's source source is available and you can modify it, contribute to it etc., but you can't sell or distribute Cork or modified versions of it.
-
-Moreover, you can’t distribute compiled versions of Cork without consulting me first. Compiling versions for your personal use is fine.
+This means that Cork's source source is available and you can modify it, contribute to it etc., but you can't sell it.


### PR DESCRIPTION

The commons license that you link here, does **NOT** do what you say it does. 

You can distribute a software, and also share executables, that are licensed under the commons clause:

> Commons Clause only forbids you from “selling” the Commons Clause software itself. You may develop on top of Commons Clause licensed software (adding applications, tools, utilities or plug-ins) and you may embed and redistribute Commons Clause software in a larger product, and you may distribute and even “sell” (which includes offering as a commercial SaaS service) your product. You may even provide consulting services (see clarifying discussion here). You just can’t sell a product that consists in substance of the Commons Clause software and does not add value.