### PR TITLE
fix(upgrade): ignore benign Homebrew stderr during package upgrades

### DIFF
--- a/Cork/Logic/Updating and Upgrading/Update Packages.swift
+++ b/Cork/Logic/Updating and Upgrading/Update Packages.swift
@@ -65,7 +65,20 @@ func updatePackages(updateProgressTracker: UpdateProgressTracker, detailStage: U
                 updateProgressTracker.realTimeOutput.append(RealTimeTerminalLine(line: errorLine))
             }
 
-            if errorLine.contains("tap") || errorLine.contains("No checksum defined for")
+            let isIgnorable: Bool = errorLine.contains("tap")
+                || errorLine.contains("No checksum defined for")
+                || errorLine.contains("Bottle")
+                || errorLine.contains("Fetching")
+                || errorLine.contains("Downloading")
+                || errorLine.contains("Already downloaded")
+                || errorLine.contains("Pouring")
+                || errorLine.contains("Installing")
+                || errorLine.contains("🍺")
+                || errorLine.contains("✅")
+                || errorLine.contains("==>")
+                || errorLine.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+            if isIgnorable
             {
                 updateProgressTracker.updateProgress = updateProgressTracker.updateProgress + 0.1
 


### PR DESCRIPTION
## Problem

Homebrew writes progress and status messages to stderr by design (not just errors). For example, lines like:

- `✅ Bottle frei0r (2.5.6)`
- `==> Downloading ...`
- `🍺 /usr/local/Cellar/...`

Cork treats nearly all stderr output as errors, so every successful upgrade produces a **"Packages updated with errors"** dialog — even though nothing actually failed.

## Fix

Expand the ignorable stderr pattern list in `Update Packages.swift` to cover common benign Homebrew output:

| Pattern | Reason |
|---------|--------|
| `Bottle` | Bottle download/pour status |
| `Fetching` | Dependency fetching |
| `Downloading` | Download progress |
| `Already downloaded` | Cached bottle |
| `Pouring` | Bottle installation |
| `Installing` | Package installation |
| `🍺` | Homebrew success indicator |
| `✅` | Homebrew success indicator |
| `==>` | Homebrew section headers |
| Empty lines | Blank stderr output |

The existing `tap` and `No checksum defined for` patterns are preserved.

Only genuinely unexpected stderr output will now trigger the error dialog.

## Notes

- Homebrew is not localized — all CLI output is hardcoded English, so these patterns are locale-agnostic.
- The emoji patterns (`✅`, `🍺`) are not language-dependent either.