### PR TITLE
fix(sidebar): replace force unwraps in package sorting closures

### DIFF
--- a/Cork/Views/Sidebar/Components/Casks Section.swift
+++ b/Cork/Views/Sidebar/Components/Casks Section.swift
@@ -57,9 +57,9 @@ struct CasksSection: View
                         case .alphabetically:
                             return firstPackage.name(withPrecision: .precise) < secondPackage.name(withPrecision: .precise)
                         case .byInstallDate:
-                            return firstPackage.installedOn! < secondPackage.installedOn!
+                            return (firstPackage.installedOn ?? .distantPast) < (secondPackage.installedOn ?? .distantPast)
                         case .bySize:
-                            return firstPackage.sizeInBytes! > secondPackage.sizeInBytes!
+                            return (firstPackage.sizeInBytes ?? 0) > (secondPackage.sizeInBytes ?? 0)
                         }
                     }))
                     { cask in

--- a/Cork/Views/Sidebar/Components/Formulae Section.swift
+++ b/Cork/Views/Sidebar/Components/Formulae Section.swift
@@ -59,9 +59,9 @@ struct FormulaeSection: View
                         case .alphabetically:
                             return firstPackage.name(withPrecision: .precise) < secondPackage.name(withPrecision: .precise)
                         case .byInstallDate:
-                            return firstPackage.installedOn! < secondPackage.installedOn!
+                            return (firstPackage.installedOn ?? .distantPast) < (secondPackage.installedOn ?? .distantPast)
                         case .bySize:
-                            return firstPackage.sizeInBytes! > secondPackage.sizeInBytes!
+                            return (firstPackage.sizeInBytes ?? 0) > (secondPackage.sizeInBytes ?? 0)
                         }
                     }))
                     { formula in


### PR DESCRIPTION
## Summary

- Replace force unwraps of `installedOn!` and `sizeInBytes!` in sidebar sorting closures with nil-coalescing fallbacks
- Fixes `EXC_BREAKPOINT (SIGTRAP)` crash on main thread during `Section` view body evaluation when sorting by install date or size

## Root Cause

Both `BrewPackage.installedOn` (`Date?`) and `BrewPackage.sizeInBytes` (`Int64?`) are Optional, but the sorting closures in `FormulaeSection` and `CasksSection` force-unwrap them. Packages can have `nil` for these fields when:

- Created from `MinimalHomebrewPackage` (which sets `sizeInBytes: nil`)
- Directory size computation is still running on background threads
- The package folder's creation date couldn't be read

When the user sorts by `.byInstallDate` or `.bySize`, the `ForEach` sorting closure executes during `Section.init` on the main thread and crashes on the nil force unwrap.

## Fix

Use nil-coalescing operators instead of force unwraps:
- `installedOn ?? .distantPast` — packages with unknown install dates sort to the bottom
- `sizeInBytes ?? 0` — packages with unknown sizes sort to the bottom

## Test plan

- [ ] Build and run Cork with sorting set to "by size" while packages are still loading
- [ ] Build and run Cork with sorting set to "by install date"
- [ ] Verify alphabetical sorting is unaffected
- [ ] Verify packages with nil sizes/dates appear at the end of the sorted list