### PR TITLE
feat(sudo): use Touch ID when pam_tid is configured

### DIFF
--- a/Modules/TerminalSupport/Logic/Shell Commands.swift
+++ b/Modules/TerminalSupport/Logic/Shell Commands.swift
@@ -106,22 +106,35 @@ public func shell(
         task.currentDirectoryURL = workingDirectory
     }
     
-    let sudoHelperURL: URL = Bundle.main.resourceURL!.appendingPathComponent("Sudo Helper", conformingTo: .executable)
-    
-    finalEnvironment["SUDO_ASKPASS"] = sudoHelperURL.path
-    
+    // MARK: - Configure sudo authentication
+
+    /// When Touch ID for sudo is enabled, provide a PTY so sudo goes through PAM
+    /// (which triggers Touch ID) instead of using the askpass helper
+    var ptyHandles: (master: FileHandle, slave: FileHandle)?
+
+    if isTouchIDSudoEnabled(), let pty = createPseudoTerminal()
+    {
+        task.standardInput = pty.slave
+        ptyHandles = pty
+    }
+    else
+    {
+        let sudoHelperURL: URL = Bundle.main.resourceURL!.appendingPathComponent("Sudo Helper", conformingTo: .executable)
+        finalEnvironment["SUDO_ASKPASS"] = sudoHelperURL.path
+    }
+
     task.environment = finalEnvironment
     task.launchPath = launchPath.absoluteString
-    
+
     /// Filter out empty things from the arguments so they don't fuck it up
     task.arguments = arguments.filter({ $0 != "" })
-    
+
     let pipe: Pipe = .init()
     task.standardOutput = pipe
-    
+
     let errorPipe: Pipe = .init()
     task.standardError = errorPipe
-    
+
     do
     {
         try task.run()
@@ -130,7 +143,7 @@ public func shell(
     {
         AppConstants.shared.logger.error("\(String(describing: error))")
     }
-    
+
     return AsyncStream
     { continuation in
         pipe.fileHandleForReading.readabilityHandler = { handler in
@@ -139,29 +152,32 @@ public func shell(
             {
                 return
             }
-            
+
             guard !standardOutput.isEmpty
             else
             {
                 return
             }
-            
+
             continuation.yield(.standardOutput(standardOutput))
         }
-        
+
         errorPipe.fileHandleForReading.readabilityHandler = { handler in
             guard let errorOutput = String(data: handler.availableData, encoding: .utf8)
             else
             {
                 return
             }
-            
+
             guard !errorOutput.isEmpty else { return }
-            
+
             continuation.yield(.standardError(errorOutput))
         }
-        
-        task.terminationHandler = { _ in
+
+        task.terminationHandler = { [ptyHandles] _ in
+            /// Close PTY file handles when the process exits
+            ptyHandles?.master.closeFile()
+            ptyHandles?.slave.closeFile()
             continuation.finish()
         }
     }
@@ -231,13 +247,26 @@ public func shell(
         task.currentDirectoryURL = workingDirectory
     }
 
-    let sudoHelperURL: URL = Bundle.main.resourceURL!.appendingPathComponent("Sudo Helper", conformingTo: .executable)
+    // MARK: - Configure sudo authentication
 
-    finalEnvironment["SUDO_ASKPASS"] = sudoHelperURL.path
+    /// When Touch ID for sudo is enabled, provide a PTY so sudo goes through PAM
+    /// (which triggers Touch ID) instead of using the askpass helper
+    var ptyHandles: (master: FileHandle, slave: FileHandle)?
+
+    if isTouchIDSudoEnabled(), let pty = createPseudoTerminal()
+    {
+        task.standardInput = pty.slave
+        ptyHandles = pty
+    }
+    else
+    {
+        let sudoHelperURL: URL = Bundle.main.resourceURL!.appendingPathComponent("Sudo Helper", conformingTo: .executable)
+        finalEnvironment["SUDO_ASKPASS"] = sudoHelperURL.path
+    }
 
     task.environment = finalEnvironment
     task.launchPath = launchPath.absoluteString
-    
+
     /// Filter out empty things from the arguments so they don't fuck it up
     task.arguments = arguments.filter({ $0 != "" })
 
@@ -286,7 +315,10 @@ public func shell(
             continuation.yield(.standardError(errorOutput))
         }
 
-        task.terminationHandler = { _ in
+        task.terminationHandler = { [ptyHandles] _ in
+            /// Close PTY file handles when the process exits
+            ptyHandles?.master.closeFile()
+            ptyHandles?.slave.closeFile()
             continuation.finish()
         }
     }

--- a/Modules/TerminalSupport/Logic/Touch ID Sudo.swift
+++ b/Modules/TerminalSupport/Logic/Touch ID Sudo.swift
@@ -1,0 +1,110 @@
+//
+//  Touch ID Sudo.swift
+//  Cork
+//
+//  Created by Dávid Balatoni on 11.04.2026.
+//
+
+import Foundation
+import CorkShared
+
+/// Checks whether Touch ID for sudo is configured on this system by inspecting PAM configuration.
+///
+/// macOS uses `/etc/pam.d/sudo_local` (preferred, user-editable) and `/etc/pam.d/sudo`
+/// for sudo authentication. If `pam_tid.so` appears as a `sufficient` auth module,
+/// Touch ID can be used for sudo authentication.
+public func isTouchIDSudoEnabled() -> Bool
+{
+    let pamPaths: [String] = [
+        "/etc/pam.d/sudo_local",
+        "/etc/pam.d/sudo"
+    ]
+
+    for path in pamPaths
+    {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8)
+        else
+        {
+            continue
+        }
+
+        let lines = contents.components(separatedBy: .newlines)
+        for line in lines
+        {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            /// Skip comments and empty lines
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#")
+            else
+            {
+                continue
+            }
+
+            if trimmed.contains("pam_tid.so")
+            {
+                AppConstants.shared.logger.info("Touch ID for sudo is enabled (found pam_tid.so in \(path))")
+                return true
+            }
+        }
+    }
+
+    AppConstants.shared.logger.info("Touch ID for sudo is not configured")
+    return false
+}
+
+/// Creates a pseudo-terminal pair for use with processes that need a TTY.
+///
+/// When Touch ID for sudo is enabled, `sudo` must go through PAM's interactive auth
+/// (not `SUDO_ASKPASS`), which requires a terminal. This creates a PTY pair so the
+/// child process sees a real terminal on its stdin.
+///
+/// - Returns: A tuple of (master file handle, slave file handle), or `nil` if allocation fails.
+///   The caller is responsible for closing both file descriptors when done.
+public func createPseudoTerminal() -> (master: FileHandle, slave: FileHandle)?
+{
+    let master: Int32 = posix_openpt(O_RDWR | O_NOCTTY)
+    guard master >= 0
+    else
+    {
+        AppConstants.shared.logger.warning("Failed to open pseudo-terminal master")
+        return nil
+    }
+
+    guard grantpt(master) == 0
+    else
+    {
+        AppConstants.shared.logger.warning("Failed to grant pseudo-terminal")
+        close(master)
+        return nil
+    }
+
+    guard unlockpt(master) == 0
+    else
+    {
+        AppConstants.shared.logger.warning("Failed to unlock pseudo-terminal")
+        close(master)
+        return nil
+    }
+
+    guard let slavePath = ptsname(master)
+    else
+    {
+        AppConstants.shared.logger.warning("Failed to get pseudo-terminal slave path")
+        close(master)
+        return nil
+    }
+
+    let slave: Int32 = open(slavePath, O_RDWR)
+    guard slave >= 0
+    else
+    {
+        AppConstants.shared.logger.warning("Failed to open pseudo-terminal slave")
+        close(master)
+        return nil
+    }
+
+    return (
+        master: FileHandle(fileDescriptor: master, closeOnDealloc: true),
+        slave: FileHandle(fileDescriptor: slave, closeOnDealloc: true)
+    )
+}


### PR DESCRIPTION
## Summary

- When the system has Touch ID for sudo enabled (`pam_tid.so` in `/etc/pam.d/sudo_local` or `/etc/pam.d/sudo`), Cork now skips setting `SUDO_ASKPASS` and instead allocates a pseudo-terminal on stdin so Homebrew's `sudo` calls go through PAM, triggering the native Touch ID dialog
- Falls back to the existing askpass-based Sudo Helper on systems without Touch ID for sudo
- PTY file handles are cleaned up in the process termination handler

## How it works

Homebrew only uses `sudo -A` (askpass mode, which bypasses PAM entirely) when `SUDO_ASKPASS` is set in the environment. By not setting it and giving the process a PTY — so `isatty(stdin)` returns true for the child — `sudo` proceeds with standard PAM authentication, which includes `pam_tid.so` and presents the system Touch ID dialog.

## Test plan

- [x] On a Mac with Touch ID for sudo enabled (`pam_tid.so` uncommented in `/etc/pam.d/sudo_local`), install or uninstall a cask that requires sudo — Touch ID dialog should appear instead of the password prompt
- [ ] On a Mac without Touch ID for sudo, the existing password dialog (Sudo Helper) should appear as before
- [ ] Verify PTY resources are properly cleaned up after process termination (no file descriptor leaks)

Closes #593