### PR TITLE
perf(uninstall): remove package from tracker instead of full resync

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -654,7 +654,6 @@ private extension View
                     {
                         try await view.brewPackagesTracker.uninstallSelectedPackage(
                             package: packageToUninstall,
-                            cachedDownloadsTracker: view.cachedDownloadsTracker,
                             appState: view.appState,
                             outdatedPackagesTracker: view.outdatedPackagesTracker,
                             shouldRemoveAllAssociatedFiles: false
@@ -670,7 +669,6 @@ private extension View
                     {
                         try await view.brewPackagesTracker.uninstallSelectedPackage(
                             package: packageToPurge,
-                            cachedDownloadsTracker: view.cachedDownloadsTracker,
                             appState: view.appState,
                             outdatedPackagesTracker: view.outdatedPackagesTracker,
                             shouldRemoveAllAssociatedFiles: true

--- a/Cork/Views/Packages/Package Details/Sub-Views/Package Modification Buttons.swift
+++ b/Cork/Views/Packages/Package Details/Sub-Views/Package Modification Buttons.swift
@@ -74,7 +74,6 @@ struct PackageModificationButtons: View
 
                                         try await brewPackagesTracker.uninstallSelectedPackage(
                                             package: package,
-                                            cachedDownloadsTracker: cachedDownloadsTracker,
                                             appState: appState,
                                             outdatedPackagesTracker: outdatedPackagesTracker,
                                             shouldRemoveAllAssociatedFiles: false

--- a/Cork/Views/Reusables/Uninstallation/Remove Packages Buttons.swift
+++ b/Cork/Views/Reusables/Uninstallation/Remove Packages Buttons.swift
@@ -62,7 +62,6 @@ private struct RemovePackageButton: View
 
                 try await brewPackagesTracker.uninstallSelectedPackage(
                     package: package,
-                    cachedDownloadsTracker: cachedDownloadsTracker,
                     appState: appState,
                     outdatedPackagesTracker: outdatedPackagesTracker,
                     shouldRemoveAllAssociatedFiles: shouldPurge

--- a/Modules/Packages/PackagesModels/Logic/Installation & Removal/Removal/Uninstall Packages.swift
+++ b/Modules/Packages/PackagesModels/Logic/Installation & Removal/Removal/Uninstall Packages.swift
@@ -15,7 +15,6 @@ public extension BrewPackagesTracker
     @MainActor
     func uninstallSelectedPackage(
         package: BrewPackage,
-        cachedDownloadsTracker: CachedDownloadsTracker,
         appState: AppState,
         outdatedPackagesTracker: OutdatedPackagesTracker,
         shouldRemoveAllAssociatedFiles: Bool
@@ -80,24 +79,17 @@ public extension BrewPackagesTracker
         }
         else
         {
-            do
+            if !uninstallCommandOutput.standardError.isEmpty && uninstallCommandOutput.standardError.contains("Error:")
             {
-                try await self.synchronizeInstalledPackages(cachedDownloadsTracker: cachedDownloadsTracker)
-                
-                if !uninstallCommandOutput.standardError.isEmpty && uninstallCommandOutput.standardError.contains("Error:")
-                {
-                    AppConstants.shared.logger.error("There was a serious uninstall error: \(uninstallCommandOutput.standardError)")
-                    
-                    appState.showAlert(errorToShow: .fatalPackageUninstallationError(packageName: package.name(withPrecision: .precise), errorDetails: uninstallCommandOutput.standardError))
-                }
-                else
-                {
-                    AppConstants.shared.logger.info("Uninstalling can proceed")
-                }
+                AppConstants.shared.logger.error("There was a serious uninstall error: \(uninstallCommandOutput.standardError)")
+
+                appState.showAlert(errorToShow: .fatalPackageUninstallationError(packageName: package.name(withPrecision: .precise), errorDetails: uninstallCommandOutput.standardError))
             }
-            catch let synchronizationError
+            else
             {
-                appState.showAlert(errorToShow: .couldNotSynchronizePackages(error: synchronizationError.localizedDescription))
+                AppConstants.shared.logger.info("Uninstalling can proceed")
+
+                self.removePackageFromTracker(package)
             }
         }
 

--- a/Modules/Packages/PackagesModels/Trackers/Brew Packages Tracker.swift
+++ b/Modules/Packages/PackagesModels/Trackers/Brew Packages Tracker.swift
@@ -126,7 +126,31 @@ public class BrewPackagesTracker
             installedCasks.insert(.success(package))
         }
     }
-    
+
+    public func removePackageFromTracker(_ package: BrewPackage)
+    {
+        if package.type == .formula
+        {
+            if let match = installedFormulae.first(where: {
+                if case .success(let existing) = $0 { return existing.id == package.id }
+                return false
+            })
+            {
+                installedFormulae.remove(match)
+            }
+        }
+        else
+        {
+            if let match = installedCasks.first(where: {
+                if case .success(let existing) = $0 { return existing.id == package.id }
+                return false
+            })
+            {
+                installedCasks.remove(match)
+            }
+        }
+    }
+
     // MARK: - App adoption
     /// All adoptable apps, including those that are excluded
     public var adoptableApps: [AdoptableApp] = .init()


### PR DESCRIPTION
## Summary

- After uninstalling a package, Cork previously called `synchronizeInstalledPackages` which reloaded **all** formulae and casks from disk, recalculated cached downloads, and refreshed adoptable apps — just to remove one item
- Now uses a new `removePackageFromTracker(_:)` method to remove the single package from the in-memory `Set`, making the sidebar update instant
- Removed the now-unused `cachedDownloadsTracker` parameter from `uninstallSelectedPackage` and updated all 4 call sites

## Test plan

- [ ] Uninstall a formula — verify it disappears from the sidebar immediately without a visible reload
- [ ] Uninstall a cask — same behavior
- [ ] Purge a cask (--zap) — same behavior
- [ ] Attempt to uninstall a package that is a dependency of another — verify the error alert still appears correctly
- [ ] Attempt to uninstall a cask requiring sudo — verify the sudo-required sheet still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)