### PR TITLE
Add appearance override setting (System / Light / Dark) (Closes #600)

### DIFF
--- a/Cork/ContentView.swift
+++ b/Cork/ContentView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 struct ContentView: View, Sendable
 {
+    @Default(.customAppearance) var customAppearance: AppearanceOverride
     @Default(.sortPackagesBy) var sortPackagesBy: PackageSortingOptions
     @Default(.allowBrewAnalytics) var allowBrewAnalytics: Bool
 
@@ -668,6 +669,7 @@ private extension View
             }, message: { dialogType in
                 Text(dialogType.message)
             })
+            .preferredColorScheme(Defaults[.customAppearance].colorScheme)
     }
 }
 

--- a/Cork/Views/Settings/Panes/General Pane.swift
+++ b/Cork/Views/Settings/Panes/General Pane.swift
@@ -12,6 +12,7 @@ import Defaults
 
 struct GeneralPane: View
 {
+    @Default(.customAppearance) var customAppearance: AppearanceOverride
     @Default(.sortPackagesBy) var sortPackagesBy: PackageSortingOptions
     @Default(.displayAdvancedDependencies) var displayAdvancedDependencies: Bool
 
@@ -39,6 +40,17 @@ struct GeneralPane: View
         {
             Form
             {
+                Picker(selection: $customAppearance)
+                {
+                    ForEach(AppearanceOverride.allCases)
+                    { appearanceOption in
+                        Text(appearanceOption.description)
+                            .tag(appearanceOption)
+                    }
+                } label: {
+                    Text("settings.general.appearance")
+                }
+
                 Picker(selection: $sortPackagesBy) {
                     ForEach(PackageSortingOptions.allCases)
                     { packageSortingOption in

--- a/Modules/Shared/Defaults/Settings/General Settings.swift
+++ b/Modules/Shared/Defaults/Settings/General Settings.swift
@@ -57,4 +57,8 @@ public extension Defaults.Keys
     /// Whether the app should start without its window
     /// Not implemented at the moment
     static let startWithoutWindow: Key<Bool> = .init("startWithoutWindow", default: false)
+
+    // MARK: - Appearance
+    /// Custom Light/Dark/System appearance override
+    static let customAppearance: Key<AppearanceOverride> = .init("customAppearance", default: .system)
 }

--- a/Modules/Shared/Enums/Appearance Override.swift
+++ b/Modules/Shared/Enums/Appearance Override.swift
@@ -1,0 +1,45 @@
+//
+//  Appearance Override.swift
+//  CorkShared
+//
+//  Created by Ameer Hamza on 09.08.2026.
+//
+
+import Foundation
+import SwiftUI
+import Defaults
+
+public enum AppearanceOverride: String, Codable, CaseIterable, Identifiable, Defaults.Serializable
+{
+    case system = "system"
+    case light = "light"
+    case dark = "dark"
+
+    public var id: Self { self }
+
+    public var description: LocalizedStringResource
+    {
+        switch self
+        {
+        case .system:
+            return LocalizedStringResource("settings.general.appearance.system", defaultValue: "System")
+        case .light:
+            return LocalizedStringResource("settings.general.appearance.light", defaultValue: "Light")
+        case .dark:
+            return LocalizedStringResource("settings.general.appearance.dark", defaultValue: "Dark")
+        }
+    }
+
+    public var colorScheme: ColorScheme?
+    {
+        switch self
+        {
+        case .system:
+            return nil
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR resolves #600 by adding a user setting in **Settings -> General** to override the app's appearance mode:

- **System** (Default)
- **Light**
- **Dark**

### Changes
1. Added `AppearanceOverride` enum in `CorkShared` module.
2. Added `customAppearance` default setting key in `General Settings.swift`.
3. Added Appearance Picker control in `General Pane.swift`.
4. Applied `.preferredColorScheme(Defaults[.customAppearance].colorScheme)` modifier to `ContentView`.

## Mandatory Information

### AI / LLM Use

Did you use any AIs / LLMs to create any part of this pull request?

- [x] Yes
- [ ] No

#### If Yes — How was it used? *(mandatory)*

I used LLMs to help structure the `AppearanceOverride` enum in `CorkShared` and integrate the `.preferredColorScheme` modifier in `ContentView.swift`.
