### PR TITLE
fix: treat brew stderr warnings as non-fatal

### DIFF
--- a/Cork/Logic/Updating and Upgrading/Update All Packages.swift
+++ b/Cork/Logic/Updating and Upgrading/Update All Packages.swift
@@ -58,7 +58,9 @@ extension OutdatedPackagesTracker
         
         var processError: UpdateAllPackagesView.CompleteUpdatingError?
 
-        for await output in shell(AppConstants.shared.brewExecutablePath, ["upgrade", includeGreedyPackages ? "--greedy" : ""])
+        let (updateStream, updateProcess): (AsyncStream<TerminalOutput>, Process) = shell(AppConstants.shared.brewExecutablePath, ["upgrade", includeGreedyPackages ? "--greedy" : ""])
+
+        for await output in updateStream
         {
             updateProgressTracker.insertOutput(output)
 
@@ -100,14 +102,22 @@ extension OutdatedPackagesTracker
             }
         }
 
+        /// Use exit code to judge stream final status
+        let brewExitCode: Int32 = updateProcess.terminationStatus
+
         if let processError
         {
             throw processError
         }
+
+        if brewExitCode != 0
+        {
+            throw .containsUnexpectedOutputs(consolidatedUnexpectedOutputs)
+        }
         
         if !consolidatedUnexpectedOutputs.isEmpty
         {
-            throw .containsUnexpectedOutputs(consolidatedUnexpectedOutputs)
+            self.appConstants.logger.warning("Upgrade finished successfully with unrecognised output: \(consolidatedUnexpectedOutputs.map(\.description), privacy: .public)")
         }
     }
 }

--- a/Modules/Packages/PackagesModels/Logic/Package Loading/Get Outdated Packages.swift
+++ b/Modules/Packages/PackagesModels/Logic/Package Loading/Get Outdated Packages.swift
@@ -107,8 +107,9 @@ public extension OutdatedPackagesTracker
 
         if rawOutput.containsErrors
         {
-            AppConstants.shared.logger.error("Standard error for package updating is not empty: \(rawOutput.standardErrors)")
-            throw OutdatedPackageRetrievalError.otherError(rawOutput.standardErrors.formatted(.list(type: .and)))
+            // Homebrew writes harmless warning information to stderr
+            // Also might exist successfully with valid stdout
+            AppConstants.shared.logger.warning("`brew outdated` wrote to stderr, but its JSON output is still expected to be valid: \(rawOutput.standardErrors)")
         }
 
         // MARK: - Decoding
@@ -127,7 +128,9 @@ public extension OutdatedPackagesTracker
             {
                 AppConstants.shared.logger.error("Could not convert raw output of decoding function to data for the decoder")
 
-                throw OutdatedPackageRetrievalError.otherError("There was a failure encoding data")
+                let failureReason: String = rawOutput.standardErrors.isEmpty ? "There was a failure encoding data" : rawOutput.standardErrors.formatted(.list(type: .and))
+
+                throw OutdatedPackageRetrievalError.otherError(failureReason)
             }
             let rawDecodedOutdatedPackages: OutdatedPackageCommandOutput = try outdatedPackagesOutputDecoder.decode(OutdatedPackageCommandOutput.self, from: decodableOutput)
 

--- a/Modules/TerminalSupport/Logic/Shell Commands.swift
+++ b/Modules/TerminalSupport/Logic/Shell Commands.swift
@@ -290,7 +290,7 @@ public func shell(
         finalEnvironment["ALL_PROXY"] = "\(proxySettings.host):\(proxySettings.port)"
     }
 
-    if Defaults[.isAutomaticCleanupEnabled]
+    if !Defaults[.isAutomaticCleanupEnabled]
     {
         finalEnvironment["HOMEBREW_NO_INSTALL_CLEANUP"] = "TRUE"
     }


### PR DESCRIPTION
Homebrew writes some harmless warnings to stderr while still exiting successfully with valid JSON on stdout. Success is now determined by the actual result instead of the presence of stderr content.

- Scanning (brew outdated) fails only when stdout yields no JSON or the JSON cannot be decoded; stderr content is logged, and included in the error message on real failures
- Upgrading (brew upgrade) is now judged by the process exit code instead of unrecognized output lines; on success such output is only logged
- The third shell() overload now sets HOMEBREW_NO_INSTALL_CLEANUP only when automatic cleanup is disabled, matching the other two overloads

Fixes #670

## Mandatory Information
 
### AI / LLM Use
 
Did you use any AIs / LLMs to create any part of this pull request?
 
- [ x] Yes
- [ ] No
 
#### If Yes — How was it used? *(mandatory)*
 
<!--
  Required if you selected "Yes" above. Describe how AI/LLMs were used.
-->
 
I used AI to help locating the sections which cause error and doing a analysis.
Then I wrote the code and did a test via Xcode to make sure the relevant error disappears.